### PR TITLE
feat: Custom workspace display names

### DIFF
--- a/GlazeWM.Bar/Components/WorkspacesComponent.xaml
+++ b/GlazeWM.Bar/Components/WorkspacesComponent.xaml
@@ -18,7 +18,7 @@
       <DataTemplate>
         <Button
           x:Name="WorkspaceButton"
-          Content="{Binding Name}"
+          Content="{Binding CustomDisplayName}"
           Command="{Binding DataContext.FocusWorkspaceCommand, ElementName=_workspacesComponent}"
           CommandParameter="{Binding Name}"
           Background="{Binding DataContext.DefaultWorkspaceBackground, ElementName=_workspacesComponent}"

--- a/GlazeWM.Domain/Workspaces/Workspace.cs
+++ b/GlazeWM.Domain/Workspaces/Workspace.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using GlazeWM.Domain.Containers;
 using GlazeWM.Domain.Monitors;
 using GlazeWM.Domain.UserConfigs;
@@ -10,6 +11,9 @@ namespace GlazeWM.Domain.Workspaces
   public class Workspace : SplitContainer
   {
     public string Name { get; set; }
+
+    public string CustomDisplayName =>
+      _userConfigService.UserConfig.Workspaces.First(w => w.Name == Name).CustomDisplayName ?? Name;
 
     private UserConfigService _userConfigService =
         ServiceLocator.Provider.GetRequiredService<UserConfigService>();


### PR DESCRIPTION
Since the config property already existed but wasn't bound to the UI this was quite a basic change.