### PR TITLE
feat: bind workspaces to specific monitors

### DIFF
--- a/GlazeWM.Domain/Monitors/CommandHandlers/AddMonitorHandler.cs
+++ b/GlazeWM.Domain/Monitors/CommandHandlers/AddMonitorHandler.cs
@@ -49,9 +49,9 @@ namespace GlazeWM.Domain.Monitors.CommandHandlers
 
     private void ActivateWorkspaceOnMonitor(Monitor monitor)
     {
-      // Get name of first workspace that is not active.
-      var inactiveWorkspaceName =
-        _workspaceService.GetInactiveWorkspaceNames().ElementAtOrDefault(0);
+      // Get name of first workspace that is not active for that specified monitor or any.
+      var inactiveWorkspaceName = _workspaceService.GetInactiveWorkspaceNameForMonitor(monitor) ??
+                                  _workspaceService.GetInactiveWorkspaceNames().ElementAtOrDefault(0);
 
       if (inactiveWorkspaceName == null)
         throw new FatalUserException("At least 1 workspace is required per monitor.");

--- a/GlazeWM.Domain/Monitors/CommandHandlers/AddMonitorHandler.cs
+++ b/GlazeWM.Domain/Monitors/CommandHandlers/AddMonitorHandler.cs
@@ -51,7 +51,7 @@ namespace GlazeWM.Domain.Monitors.CommandHandlers
     {
       // Get name of first workspace that is not active for that specified monitor or any.
       var inactiveWorkspaceName = _workspaceService.GetInactiveWorkspaceNameForMonitor(monitor) ??
-                                  _workspaceService.GetInactiveWorkspaceNames().ElementAtOrDefault(0);
+                                  _workspaceService.GetInactiveWorkspaceNamesNotDedicatedToAMonitor().ElementAtOrDefault(0);
 
       if (inactiveWorkspaceName == null)
         throw new FatalUserException("At least 1 workspace is required per monitor.");

--- a/GlazeWM.Domain/Monitors/CommandHandlers/AddMonitorHandler.cs
+++ b/GlazeWM.Domain/Monitors/CommandHandlers/AddMonitorHandler.cs
@@ -51,7 +51,8 @@ namespace GlazeWM.Domain.Monitors.CommandHandlers
     {
       // Get name of first workspace that is not active for that specified monitor or any.
       var inactiveWorkspaceName = _workspaceService.GetInactiveWorkspaceNameForMonitor(monitor) ??
-                                  _workspaceService.GetInactiveWorkspaceNamesNotDedicatedToAMonitor().ElementAtOrDefault(0);
+                                  _workspaceService.GetInactiveWorkspaceNamesNotDedicatedToAMonitor().ElementAtOrDefault(0) ??
+                                  _workspaceService.GetInactiveWorkspaceNames().ElementAtOrDefault(0);
 
       if (inactiveWorkspaceName == null)
         throw new FatalUserException("At least 1 workspace is required per monitor.");

--- a/GlazeWM.Domain/Monitors/MonitorService.cs
+++ b/GlazeWM.Domain/Monitors/MonitorService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Windows.Forms;
 using GlazeWM.Domain.Common.Enums;
 using GlazeWM.Domain.Containers;
+using GlazeWM.Domain.UserConfigs;
 using GlazeWM.Infrastructure.WindowsApi;
 using static GlazeWM.Infrastructure.WindowsApi.WindowsApiService;
 
@@ -12,10 +13,12 @@ namespace GlazeWM.Domain.Monitors
   public class MonitorService
   {
     private readonly ContainerService _containerService;
+    private readonly UserConfigService _userConfigService;
 
-    public MonitorService(ContainerService containerService)
+    public MonitorService(ContainerService containerService, UserConfigService userConfigService)
     {
       _containerService = containerService;
+      _userConfigService = userConfigService;
     }
 
     /// <summary>
@@ -24,6 +27,12 @@ namespace GlazeWM.Domain.Monitors
     public IEnumerable<Monitor> GetMonitors()
     {
       return _containerService.ContainerTree.Children.Cast<Monitor>();
+    }
+
+    public Monitor GetMonitorForWorkspace(string workspace)
+    {
+      var monitorName = _userConfigService.UserConfig.Workspaces.FirstOrDefault(ws => ws.Name == workspace)?.BindToMonitor;
+      return GetMonitors().FirstOrDefault(m => m.DeviceName == monitorName);
     }
 
     public static Monitor GetMonitorFromChildContainer(Container container)

--- a/GlazeWM.Domain/UserConfigs/WorkspaceConfig.cs
+++ b/GlazeWM.Domain/UserConfigs/WorkspaceConfig.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace GlazeWM.Domain.UserConfigs
@@ -6,7 +7,14 @@ namespace GlazeWM.Domain.UserConfigs
   {
     [Required]
     public string Name { get; set; }
-    public string BindToMonitor { get; set; }
+
+    private string _bindToMonitor;
+    public string BindToMonitor
+    {
+      get => int.TryParse(_bindToMonitor, out var monitorIndex) ? $@"\\.\DISPLAY{monitorIndex}" : _bindToMonitor;
+      set => _bindToMonitor = value;
+    }
+
     public string DisplayName { get; set; }
     public bool KeepAlive { get; set; }
   }

--- a/GlazeWM.Domain/Workspaces/CommandHandlers/FocusWorkspaceHandler.cs
+++ b/GlazeWM.Domain/Workspaces/CommandHandlers/FocusWorkspaceHandler.cs
@@ -92,8 +92,8 @@ namespace GlazeWM.Domain.Workspaces.CommandHandlers
     /// </summary>
     private Workspace ActivateWorkspace(string workspaceName)
     {
-      var focusedMonitor = _monitorService.GetFocusedMonitor();
-      _bus.Invoke(new ActivateWorkspaceCommand(workspaceName, focusedMonitor));
+      var targetMonitor = _monitorService.GetMonitorForWorkspace(workspaceName) ?? _monitorService.GetFocusedMonitor();
+      _bus.Invoke(new ActivateWorkspaceCommand(workspaceName, targetMonitor));
 
       return _workspaceService.GetActiveWorkspaceByName(workspaceName);
     }

--- a/GlazeWM.Domain/Workspaces/CommandHandlers/MoveWindowToWorkspaceHandler.cs
+++ b/GlazeWM.Domain/Workspaces/CommandHandlers/MoveWindowToWorkspaceHandler.cs
@@ -14,16 +14,19 @@ namespace GlazeWM.Domain.Workspaces.CommandHandlers
     private readonly Bus _bus;
     private readonly WorkspaceService _workspaceService;
     private readonly ContainerService _containerService;
+    private readonly MonitorService _monitorService;
 
     public MoveWindowToWorkspaceHandler(
       Bus bus,
       WorkspaceService workspaceService,
-      ContainerService containerService
+      ContainerService containerService,
+      MonitorService monitorService
     )
     {
       _bus = bus;
       _workspaceService = workspaceService;
       _containerService = containerService;
+      _monitorService = monitorService;
     }
 
     public CommandResponse Handle(MoveWindowToWorkspaceCommand command)
@@ -32,7 +35,8 @@ namespace GlazeWM.Domain.Workspaces.CommandHandlers
       var workspaceName = command.WorkspaceName;
 
       var currentWorkspace = WorkspaceService.GetWorkspaceFromChildContainer(windowToMove);
-      var currentMonitor = MonitorService.GetMonitorFromChildContainer(currentWorkspace);
+      // Make sure workspace opens on the appropriate monitor
+      var currentMonitor = _monitorService.GetMonitorForWorkspace(workspaceName) ?? MonitorService.GetMonitorFromChildContainer(currentWorkspace);
 
       var targetWorkspace = _workspaceService.GetActiveWorkspaceByName(workspaceName)
         ?? ActivateWorkspace(workspaceName, currentMonitor);

--- a/GlazeWM.Domain/Workspaces/CommandHandlers/MoveWindowToWorkspaceHandler.cs
+++ b/GlazeWM.Domain/Workspaces/CommandHandlers/MoveWindowToWorkspaceHandler.cs
@@ -36,10 +36,10 @@ namespace GlazeWM.Domain.Workspaces.CommandHandlers
 
       var currentWorkspace = WorkspaceService.GetWorkspaceFromChildContainer(windowToMove);
       // Make sure workspace opens on the appropriate monitor
-      var currentMonitor = _monitorService.GetMonitorForWorkspace(workspaceName) ?? MonitorService.GetMonitorFromChildContainer(currentWorkspace);
+      var targetMonitor = _monitorService.GetMonitorForWorkspace(workspaceName) ?? MonitorService.GetMonitorFromChildContainer(currentWorkspace);
 
       var targetWorkspace = _workspaceService.GetActiveWorkspaceByName(workspaceName)
-        ?? ActivateWorkspace(workspaceName, currentMonitor);
+        ?? ActivateWorkspace(workspaceName, targetMonitor);
 
       // Since target workspace could be on a different monitor, adjustments might need to be made
       // because of DPI.

--- a/GlazeWM.Domain/Workspaces/WorkspaceService.cs
+++ b/GlazeWM.Domain/Workspaces/WorkspaceService.cs
@@ -32,7 +32,7 @@ namespace GlazeWM.Domain.Workspaces
       return GetActiveWorkspaces().FirstOrDefault(workspace => workspace.Name == name);
     }
 
-    public IEnumerable<string> GetInactiveWorkspaceNames()
+    private IEnumerable<string> GetInactiveWorkspaceNames()
     {
       var activeWorkspaces = GetActiveWorkspaces();
 
@@ -46,7 +46,15 @@ namespace GlazeWM.Domain.Workspaces
     public string GetInactiveWorkspaceNameForMonitor(Monitor monitor)
     {
       return GetInactiveWorkspaceNames()
-        .FirstOrDefault(w => _userConfigService.UserConfig.Workspaces.First(uw => uw.Name == w).BindToMonitor == monitor.DeviceName);
+        .FirstOrDefault(w =>
+          _userConfigService.UserConfig.Workspaces.First(uw => uw.Name == w).BindToMonitor == monitor.DeviceName);
+    }
+
+    public IEnumerable<string> GetInactiveWorkspaceNamesNotDedicatedToAMonitor()
+    {
+      return GetInactiveWorkspaceNames()
+        .Where(w => string.IsNullOrWhiteSpace(_userConfigService.UserConfig.Workspaces.First(uw => uw.Name == w)
+          .BindToMonitor));
     }
 
     public static Workspace GetWorkspaceFromChildContainer(Container container)

--- a/GlazeWM.Domain/Workspaces/WorkspaceService.cs
+++ b/GlazeWM.Domain/Workspaces/WorkspaceService.cs
@@ -32,7 +32,7 @@ namespace GlazeWM.Domain.Workspaces
       return GetActiveWorkspaces().FirstOrDefault(workspace => workspace.Name == name);
     }
 
-    private IEnumerable<string> GetInactiveWorkspaceNames()
+    public IEnumerable<string> GetInactiveWorkspaceNames()
     {
       var activeWorkspaces = GetActiveWorkspaces();
 

--- a/GlazeWM.Domain/Workspaces/WorkspaceService.cs
+++ b/GlazeWM.Domain/Workspaces/WorkspaceService.cs
@@ -2,6 +2,7 @@
 using GlazeWM.Domain.UserConfigs;
 using System.Collections.Generic;
 using System.Linq;
+using GlazeWM.Domain.Monitors;
 
 namespace GlazeWM.Domain.Workspaces
 {
@@ -40,6 +41,12 @@ namespace GlazeWM.Domain.Workspaces
       );
 
       return inactiveWorkspaceConfigs.Select(config => config.Name);
+    }
+    
+    public string GetInactiveWorkspaceNameForMonitor(Monitor monitor)
+    {
+      return GetInactiveWorkspaceNames()
+        .FirstOrDefault(w => _userConfigService.UserConfig.Workspaces.First(uw => uw.Name == w).BindToMonitor == monitor.DeviceName);
     }
 
     public static Workspace GetWorkspaceFromChildContainer(Container container)


### PR DESCRIPTION
This is the only PR im not 100% happy with as the DisplayNames are quite generic (e.g. `\\.\DISPLAY1`).

Ideally in my opinion, it'd be cool to have the actual monitor names as usable strings on the config. I've googled around a bit and apparently it's quite hard to figure that out, so I haven't tried to implement that.

