### PR TITLE
feat: improve behavior on crash

### DIFF
--- a/GlazeWM.Bootstrapper/Startup.cs
+++ b/GlazeWM.Bootstrapper/Startup.cs
@@ -13,7 +13,6 @@ using GlazeWM.Infrastructure.Bussing;
 using GlazeWM.Infrastructure.WindowsApi;
 using GlazeWM.Infrastructure.WindowsApi.Events;
 using System;
-using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Windows.Forms;
@@ -58,44 +57,30 @@ namespace GlazeWM.Bootstrapper
 
     public void Run()
     {
-      try
-      {
-        // Set the process-default DPI awareness.
-        SetProcessDpiAwarenessContext(DpiAwarenessContext.Context_PerMonitorAwareV2);
+      // Set the process-default DPI awareness.
+      SetProcessDpiAwarenessContext(DpiAwarenessContext.Context_PerMonitorAwareV2);
 
-        // Launch bar WPF application. Spawns bar window when monitors are added, so the service needs
-        // to be initialized before populating initial state.
-        _barService.StartApp();
+      // Launch bar WPF application. Spawns bar window when monitors are added, so the service needs
+      // to be initialized before populating initial state.
+      _barService.StartApp();
 
-        // Populate initial monitors, windows, workspaces and user config.
-        PopulateInitialState();
+      // Populate initial monitors, windows, workspaces and user config.
+      PopulateInitialState();
 
-        // Listen on registered keybindings.
-        _keybindingService.Start();
+      // Listen on registered keybindings.
+      _keybindingService.Start();
 
-        // Listen for window events (eg. close, focus).
-        _windowEventService.Start();
+      // Listen for window events (eg. close, focus).
+      _windowEventService.Start();
 
-        // Listen for system-related events (eg. changes to display settings).
-        _systemEventService.Start();
+      // Listen for system-related events (eg. changes to display settings).
+      _systemEventService.Start();
 
-        // Add application to system tray.
-        _systemTrayService.AddToSystemTray();
+      // Add application to system tray.
+      _systemTrayService.AddToSystemTray();
 
-        _bus.Events.Where(@event => @event is ApplicationExitingEvent)
-          .Subscribe((@event) => OnApplicationExit());
-      }
-      catch (Exception error)
-      {
-        // Alert the user of the error.
-        // TODO: This throws duplicate errors if a command errors and it was invoked by another
-        // handler.
-        if (error is FatalUserException)
-          MessageBox.Show(error.Message);
-
-        File.AppendAllText("./errors.log", $"\n\n{error.Message + error.StackTrace}");
-        throw error;
-      }
+      _bus.Events.Where(@event => @event is ApplicationExitingEvent)
+        .Subscribe((@event) => OnApplicationExit());
     }
 
     /// <summary>

--- a/GlazeWM.Infrastructure/Bussing/Bus.cs
+++ b/GlazeWM.Infrastructure/Bussing/Bus.cs
@@ -1,8 +1,11 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using GlazeWM.Infrastructure.WindowsApi.Events;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Reactive.Subjects;
+using System.Windows.Forms;
 
 namespace GlazeWM.Infrastructure.Bussing
 {
@@ -19,17 +22,25 @@ namespace GlazeWM.Infrastructure.Bussing
     /// </summary>
     public CommandResponse Invoke<T>(T command) where T : Command
     {
-      Debug.WriteLine($"Command {command.Name} invoked.");
-
-      // Create a `Type` object representing the constructed `ICommandHandler` generic.
-      var handlerType = typeof(ICommandHandler<>).MakeGenericType(command.GetType());
-
-      var handlerInstance = ServiceLocator.Provider.GetRequiredService(handlerType)
-        as ICommandHandler<T>;
-
-      lock (_lockObj)
+      try
       {
-        return handlerInstance.Handle(command);
+        Debug.WriteLine($"Command {command.Name} invoked.");
+
+        // Create a `Type` object representing the constructed `ICommandHandler` generic.
+        var handlerType = typeof(ICommandHandler<>).MakeGenericType(command.GetType());
+
+        var handlerInstance = ServiceLocator.Provider.GetRequiredService(handlerType)
+          as ICommandHandler<T>;
+
+        lock (_lockObj)
+        {
+          return handlerInstance.Handle(command);
+        }
+      }
+      catch (Exception error)
+      {
+        HandleError(error);
+        throw error;
       }
     }
 
@@ -38,24 +49,53 @@ namespace GlazeWM.Infrastructure.Bussing
     /// </summary>
     public void RaiseEvent<T>(T @event) where T : Event
     {
-      Debug.WriteLine($"Event {@event.Name} emitted.");
-
-      // Create a `Type` object representing the constructed `IEventHandler` generic.
-      var handlerType = typeof(IEventHandler<>).MakeGenericType(@event.GetType());
-
-      var handlerInstances = ServiceLocator.Provider.GetServices(handlerType)
-        as IEnumerable<IEventHandler<T>>;
-
-      foreach (var handler in handlerInstances)
+      try
       {
-        lock (_lockObj)
-        {
-          handler.Handle(@event);
-        }
-      }
+        Debug.WriteLine($"Event {@event.Name} emitted.");
 
-      // Emit event through subject.
-      Events.OnNext(@event);
+        // Create a `Type` object representing the constructed `IEventHandler` generic.
+        var handlerType = typeof(IEventHandler<>).MakeGenericType(@event.GetType());
+
+        var handlerInstances = ServiceLocator.Provider.GetServices(handlerType)
+          as IEnumerable<IEventHandler<T>>;
+
+        foreach (var handler in handlerInstances)
+        {
+          lock (_lockObj)
+          {
+            handler.Handle(@event);
+          }
+        }
+
+        // Emit event through subject.
+        Events.OnNext(@event);
+      }
+      catch (Exception error)
+      {
+        HandleError(error);
+        throw error;
+      }
+    }
+
+    private void HandleError(Exception error)
+    {
+      // Alert the user of the error.
+      if (error is FatalUserException)
+        MessageBox.Show(error.Message);
+
+      WriteToErrorLog(error);
+    }
+
+    // TODO: Move to dedicated logging service.
+    private void WriteToErrorLog(Exception error)
+    {
+      var errorLogPath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        "./.glaze-wm/errors.log"
+      );
+
+      Directory.CreateDirectory(Path.GetDirectoryName(errorLogPath));
+      File.AppendAllText(errorLogPath, $"\n\n{DateTime.Now}\n{error.Message + error.StackTrace}");
     }
   }
 }

--- a/GlazeWM.Infrastructure/Bussing/Bus.cs
+++ b/GlazeWM.Infrastructure/Bussing/Bus.cs
@@ -84,6 +84,7 @@ namespace GlazeWM.Infrastructure.Bussing
         MessageBox.Show(error.Message);
 
       WriteToErrorLog(error);
+      RaiseEvent(new ApplicationExitingEvent());
     }
 
     // TODO: Move to dedicated logging service.


### PR DESCRIPTION
* Change error log path to `C:\Users\<YOUR_USER>\.glaze-wm\errors.log`. Previously error logs were stored in the directory of the `.exe` file, which is unintuitive. Also, if in the future, the application is installed in the "Program Files" directory, the error logs become increasingly difficult to access.
* Attempt cleanup and show all windows (regardless of their displayed workspace) on fatal errors.