### PR TITLE
feat: add some default window rules to sample config

### DIFF
--- a/GlazeWM.Bootstrapper/sample-config.yaml
+++ b/GlazeWM.Bootstrapper/sample-config.yaml
@@ -141,18 +141,18 @@ keybindings:
     bindings: ["Alt+Shift+9"]
 
 #LIST OF OPTIONAL IGNORED WINDOWS FOR QUALITY-OF-LIFE
-#window_rules:
-#  - command: "ignore"
-#   match_process_name: "/explorer/"
+window_rules:
+  - command: "ignore"
+    match_process_name: "/explorer/"
 
-#  - command: "ignore"
-#    match_process_name: "/Taskmgr/"
+  - command: "ignore"
+    match_process_name: "/Taskmgr/"
 
-#  - command: "ignore"
-#   match_title: "/Save As/"
+  - command: "ignore"
+    match_title: "/Save As/"
 
-#  - command: "ignore"
-#   match_title: "/Open/"
+  - command: "ignore"
+    match_title: "/Open/"
 
-#  - command: "ignore"
-#   match_process_name: "/notepad/"
+  - command: "ignore"
+    match_process_name: "/notepad/"

--- a/GlazeWM.Bootstrapper/sample-config.yaml
+++ b/GlazeWM.Bootstrapper/sample-config.yaml
@@ -141,18 +141,18 @@ keybindings:
     bindings: ["Alt+Shift+9"]
 
 #LIST OF OPTIONAL IGNORED WINDOWS FOR QUALITY-OF-LIFE
-window_rules:
-  - command: "ignore"
-    match_process_name: "/explorer/"
+#window_rules:
+#  - command: "ignore"
+#    match_process_name: "/explorer/"
 
-  - command: "ignore"
-    match_process_name: "/Taskmgr/"
+#  - command: "ignore"
+#    match_process_name: "/Taskmgr/"
 
-  - command: "ignore"
-    match_title: "/Save As/"
+#  - command: "ignore"
+#    match_title: "/Save As/"
 
-  - command: "ignore"
-    match_title: "/Open/"
+#  - command: "ignore"
+#    match_title: "/Open/"
 
-  - command: "ignore"
-    match_process_name: "/notepad/"
+#  - command: "ignore"
+#    match_process_name: "/notepad/"

--- a/GlazeWM.Bootstrapper/sample-config.yaml
+++ b/GlazeWM.Bootstrapper/sample-config.yaml
@@ -31,6 +31,19 @@ workspaces:
   - name: 8
   - name: 9
 
+window_rules:
+  # Task Manager requires admin privileges to manage and should be ignored unless running the WM as admin.
+  - command: "ignore"
+    match_process_name: "Taskmgr"
+
+  # Launches system dialogs as floating by default (eg. File Explorer save/open dialog).
+  - command: "toggle floating"
+    match_class_name: "#32770"
+
+  # Launches file copy & move dialog as floating by default.
+  - command: "toggle floating"
+    match_class_name: "OperationStatusWindow"
+
 keybindings:
   - command: "focus left"
     bindings: ["Alt+H", "Alt+Left"]
@@ -139,23 +152,3 @@ keybindings:
 
   - commands: ["move to workspace 9", "focus workspace 9"]
     bindings: ["Alt+Shift+9"]
-
-#LIST OF OPTIONAL IGNORED WINDOWS FOR QUALITY-OF-LIFE
-#window_rules:
-#  - command: "toggle floating"
-#    match_process_name: "/explorer/"
-
-#  - command: "toggle floating"
-#    match_process_name: "/notepad/"
-
-  # Task Manager requires admin privileges to manage and should be ignored unless running the WM as admin.
-  - command: "ignore"
-    match_process_name: "Taskmgr"
-
-  # Launches system dialogs as floating by default (eg. File Explorer save/open dialog).
-  - command: "toggle floating"
-    match_class_name: "#32770"
-
-  # Launches file copy & move dialog as floating by default.
-  - command: "toggle floating"
-    match_class_name: "OperationStatusWindow"

--- a/GlazeWM.Bootstrapper/sample-config.yaml
+++ b/GlazeWM.Bootstrapper/sample-config.yaml
@@ -142,17 +142,20 @@ keybindings:
 
 #LIST OF OPTIONAL IGNORED WINDOWS FOR QUALITY-OF-LIFE
 #window_rules:
-#  - command: "ignore"
+#  - command: "toggle floating"
 #    match_process_name: "/explorer/"
 
-#  - command: "ignore"
-#    match_process_name: "/Taskmgr/"
-
-#  - command: "ignore"
-#    match_title: "/Save As/"
-
-#  - command: "ignore"
-#    match_title: "/Open/"
-
-#  - command: "ignore"
+#  - command: "toggle floating"
 #    match_process_name: "/notepad/"
+
+  # Task Manager requires admin privileges to manage and should be ignored unless running the WM as admin.
+  - command: "ignore"
+    match_process_name: "Taskmgr"
+
+  # Launches system dialogs as floating by default (eg. File Explorer save/open dialog).
+  - command: "toggle floating"
+    match_class_name: "#32770"
+
+  # Launches file copy & move dialog as floating by default.
+  - command: "toggle floating"
+    match_class_name: "OperationStatusWindow"

--- a/GlazeWM.Bootstrapper/sample-config.yaml
+++ b/GlazeWM.Bootstrapper/sample-config.yaml
@@ -139,3 +139,20 @@ keybindings:
 
   - commands: ["move to workspace 9", "focus workspace 9"]
     bindings: ["Alt+Shift+9"]
+
+#LIST OF OPTIONAL IGNORED WINDOWS FOR QUALITY-OF-LIFE
+#window_rules:
+#  - command: "ignore"
+#   match_process_name: "/explorer/"
+
+#  - command: "ignore"
+#    match_process_name: "/Taskmgr/"
+
+#  - command: "ignore"
+#   match_title: "/Save As/"
+
+#  - command: "ignore"
+#   match_title: "/Open/"
+
+#  - command: "ignore"
+#   match_process_name: "/notepad/"


### PR DESCRIPTION

> includes some optional commented examples in the sample config that are like that of the README.md, with the inclusion of dialog boxes from https://github.com/lars-berger/GlazeWM/issues/58