### PR TITLE
feat: adjust windows for invisible borders

### DIFF
--- a/GlazeWM.Domain/Containers/CommandHandlers/RedrawContainersHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/RedrawContainersHandler.cs
@@ -70,10 +70,10 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
         SetWindowPos(
           window.Hwnd,
           IntPtr.Zero,
-          window.X - window.InvisibleBorders.Left,
-          window.Y - window.InvisibleBorders.Top,
-          window.Width + window.InvisibleBorders.Left + window.InvisibleBorders.Right,
-          window.Height + window.InvisibleBorders.Top + window.InvisibleBorders.Right,
+          window.X - window.BorderDelta.DeltaLeft,
+          window.Y - window.BorderDelta.DeltaTop,
+          window.Width + window.BorderDelta.DeltaLeft + window.BorderDelta.DeltaRight,
+          window.Height + window.BorderDelta.DeltaTop + window.BorderDelta.DeltaRight,
           flags
         );
         return;

--- a/GlazeWM.Domain/Containers/CommandHandlers/RedrawContainersHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/RedrawContainersHandler.cs
@@ -48,9 +48,9 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
 
         SetWindowPosition(window, flags);
 
-        // When there's a mismatch between the DPI of the monitor and the window, `SetWindowPos` might
-        // size the window incorrectly. By calling `SetWindowPos` twice, inconsistencies after the first
-        // move are resolved.
+        // When there's a mismatch between the DPI of the monitor and the window, `SetWindowPos`
+        // might size the window incorrectly. By calling `SetWindowPos` twice, inconsistencies after
+        // the first move are resolved.
         if (window.HasPendingDpiAdjustment)
         {
           SetWindowPosition(window, flags);
@@ -63,16 +63,31 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
       return CommandResponse.Ok;
     }
 
-    // TODO: Maybe only adjust for invisible borders for `TilingWindow`s.
     private void SetWindowPosition(Window window, SWP flags)
     {
+      if (window is TilingWindow)
+      {
+        SetWindowPos(
+          window.Hwnd,
+          IntPtr.Zero,
+          window.X - window.InvisibleBorders.Left,
+          window.Y - window.InvisibleBorders.Top,
+          window.Width + window.InvisibleBorders.Left + window.InvisibleBorders.Right,
+          window.Height + window.InvisibleBorders.Top + window.InvisibleBorders.Right,
+          flags
+        );
+        return;
+      }
+
+      // Avoid adjusting the borders of floating windows. Otherwise the window will increase in size
+      // from its original placement.
       SetWindowPos(
         window.Hwnd,
         IntPtr.Zero,
-        window.X - window.InvisibleBorders.Left,
-        window.Y - window.InvisibleBorders.Top,
-        window.Width + window.InvisibleBorders.Left + window.InvisibleBorders.Right,
-        window.Height + window.InvisibleBorders.Top + window.InvisibleBorders.Right,
+        window.X,
+        window.Y,
+        window.Width,
+        window.Height,
         flags
       );
     }

--- a/GlazeWM.Domain/DependencyInjection.cs
+++ b/GlazeWM.Domain/DependencyInjection.cs
@@ -59,6 +59,7 @@ namespace GlazeWM.Domain
       services.AddSingleton<ICommandHandler<MoveFocusedWindowCommand>, MoveFocusedWindowHandler>();
       services.AddSingleton<ICommandHandler<RemoveWindowCommand>, RemoveWindowHandler>();
       services.AddSingleton<ICommandHandler<ResizeFocusedWindowCommand>, ResizeFocusedWindowHandler>();
+      services.AddSingleton<ICommandHandler<ResizeFocusedWindowBordersCommand>, ResizeFocusedWindowBorderHandler>();
       services.AddSingleton<ICommandHandler<ShowAllWindowsCommand>, ShowAllWindowsHandler>();
       services.AddSingleton<ICommandHandler<ToggleFloatingCommand>, ToggleFloatingHandler>();
       services.AddSingleton<ICommandHandler<ToggleFocusedWindowFloatingCommand>, ToggleFocusedWindowFloatingHandler>();

--- a/GlazeWM.Domain/DependencyInjection.cs
+++ b/GlazeWM.Domain/DependencyInjection.cs
@@ -59,7 +59,7 @@ namespace GlazeWM.Domain
       services.AddSingleton<ICommandHandler<MoveFocusedWindowCommand>, MoveFocusedWindowHandler>();
       services.AddSingleton<ICommandHandler<RemoveWindowCommand>, RemoveWindowHandler>();
       services.AddSingleton<ICommandHandler<ResizeFocusedWindowCommand>, ResizeFocusedWindowHandler>();
-      services.AddSingleton<ICommandHandler<ResizeFocusedWindowBordersCommand>, ResizeFocusedWindowBorderHandler>();
+      services.AddSingleton<ICommandHandler<ResizeFocusedWindowBordersCommand>, ResizeFocusedWindowBordersHandler>();
       services.AddSingleton<ICommandHandler<ShowAllWindowsCommand>, ShowAllWindowsHandler>();
       services.AddSingleton<ICommandHandler<ToggleFloatingCommand>, ToggleFloatingHandler>();
       services.AddSingleton<ICommandHandler<ToggleFocusedWindowFloatingCommand>, ToggleFocusedWindowFloatingHandler>();

--- a/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
+++ b/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Text.RegularExpressions;
 using GlazeWM.Domain.Common.Commands;
 using GlazeWM.Domain.Common.Enums;
@@ -6,6 +7,8 @@ using GlazeWM.Domain.Containers.Commands;
 using GlazeWM.Domain.Windows.Commands;
 using GlazeWM.Domain.Workspaces.Commands;
 using GlazeWM.Infrastructure.Bussing;
+using GlazeWM.Infrastructure.Utils;
+using GlazeWM.Infrastructure.WindowsApi;
 
 namespace GlazeWM.Domain.UserConfigs
 {
@@ -90,6 +93,9 @@ namespace GlazeWM.Domain.UserConfigs
       {
         "height" => new ResizeFocusedWindowCommand(ResizeDimension.HEIGHT, commandParts[2]),
         "width" => new ResizeFocusedWindowCommand(ResizeDimension.WIDTH, commandParts[2]),
+        "borders" => new ResizeFocusedWindowBordersCommand(
+          ShorthandToRectDelta(string.Join(" ", commandParts[2..]))
+        ),
         _ => throw new ArgumentException(),
       };
     }
@@ -129,6 +135,22 @@ namespace GlazeWM.Domain.UserConfigs
         throw new ArgumentException();
 
       return workspaceName;
+    }
+
+    private RectDelta ShorthandToRectDelta(string shorthand)
+    {
+      var shorthandParts = shorthand.Split(" ")
+        .Select(shorthandPart => UnitsHelper.TrimUnits(shorthandPart))
+        .ToList();
+
+      return shorthandParts.Count() switch
+      {
+        1 => new RectDelta(shorthandParts[0], shorthandParts[0], shorthandParts[0], shorthandParts[0]),
+        2 => new RectDelta(shorthandParts[1], shorthandParts[0], shorthandParts[1], shorthandParts[0]),
+        3 => new RectDelta(shorthandParts[1], shorthandParts[0], shorthandParts[1], shorthandParts[2]),
+        4 => new RectDelta(shorthandParts[3], shorthandParts[0], shorthandParts[1], shorthandParts[2]),
+        _ => throw new ArgumentException(),
+      };
     }
   }
 }

--- a/GlazeWM.Domain/UserConfigs/UserConfigService.cs
+++ b/GlazeWM.Domain/UserConfigs/UserConfigService.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using GlazeWM.Domain.Windows;
 
 namespace GlazeWM.Domain.UserConfigs
 {
@@ -90,6 +91,23 @@ namespace GlazeWM.Domain.UserConfigs
       return UserConfig.Workspaces.FirstOrDefault(
         (workspaceConfig) => workspaceConfig.Name == workspaceName
       );
+    }
+
+    public IEnumerable<WindowRuleConfig> GetMatchingWindowRules(Window window)
+    {
+      return UserConfig.WindowRules.Where(rule =>
+      {
+        if (rule.ProcessNameRegex?.IsMatch(window.ProcessName) == false)
+          return false;
+
+        if (rule.ClassNameRegex?.IsMatch(window.ClassName) == false)
+          return false;
+
+        if (rule.TitleRegex?.IsMatch(window.Title) == false)
+          return false;
+
+        return true;
+      });
     }
   }
 }

--- a/GlazeWM.Domain/UserConfigs/UserConfigService.cs
+++ b/GlazeWM.Domain/UserConfigs/UserConfigService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -82,6 +82,17 @@ namespace GlazeWM.Domain.UserConfigs
 
         windowRules.Add(windowRule);
       }
+
+      // Attempt to match Electron apps by getting windows with class name 'Chrome_WidgetWin_1' and
+      // the process is not a Chromium-based browser.
+      var fixElectronBorderWindowRule = new WindowRuleConfig()
+      {
+        MatchProcessName = "/^((?!chrome).)*$/",
+        MatchClassName = "Chrome_WidgetWin_1",
+        Command = "resize borders 0px -7px -7px -7px",
+      };
+
+      windowRules.Add(fixElectronBorderWindowRule);
 
       return windowRules;
     }

--- a/GlazeWM.Domain/UserConfigs/UserConfigService.cs
+++ b/GlazeWM.Domain/UserConfigs/UserConfigService.cs
@@ -83,16 +83,17 @@ namespace GlazeWM.Domain.UserConfigs
         windowRules.Add(windowRule);
       }
 
-      // Attempt to match Electron apps by getting windows with class name 'Chrome_WidgetWin_1' and
-      // the process is not a Chromium-based browser.
-      var fixElectronBorderWindowRule = new WindowRuleConfig()
+      // Electron apps do not have invisible borders and are thus over-corrected by the default
+      // border fix. To match these apps, get windows with the class name 'Chrome_WidgetWin_1' that
+      // are not Chromium-based browsers (since the browser windows do have invisble borders).
+      var resizeElectronBorderWindowRule = new WindowRuleConfig()
       {
-        MatchProcessName = "/^((?!chrome).)*$/",
+        MatchProcessName = "/^(?!(chrome|msedge|opera)$)/",
         MatchClassName = "Chrome_WidgetWin_1",
         Command = "resize borders 0px -7px -7px -7px",
       };
 
-      windowRules.Add(fixElectronBorderWindowRule);
+      windowRules.Add(resizeElectronBorderWindowRule);
 
       return windowRules;
     }

--- a/GlazeWM.Domain/UserConfigs/UserConfigService.cs
+++ b/GlazeWM.Domain/UserConfigs/UserConfigService.cs
@@ -83,12 +83,20 @@ namespace GlazeWM.Domain.UserConfigs
         windowRules.Add(windowRule);
       }
 
+      var chromiumBrowserProcessNames = new List<string> {
+        "chrome",
+        "msedge",
+        "opera",
+        "vivaldi",
+        "brave",
+      };
+
       // Electron apps do not have invisible borders and are thus over-corrected by the default
       // border fix. To match these apps, get windows with the class name 'Chrome_WidgetWin_1' that
       // are not Chromium-based browsers (since the browser windows do have invisble borders).
       var resizeElectronBorderWindowRule = new WindowRuleConfig()
       {
-        MatchProcessName = "/^(?!(chrome|msedge|opera)$)/",
+        MatchProcessName = $"/^(?!({string.Join("|", chromiumBrowserProcessNames)})$)/",
         MatchClassName = "Chrome_WidgetWin_1",
         Command = "resize borders 0px -7px -7px -7px",
       };

--- a/GlazeWM.Domain/Windows/CommandHandlers/AddWindowHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/AddWindowHandler.cs
@@ -1,5 +1,4 @@
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using GlazeWM.Domain.Containers;
 using GlazeWM.Domain.Containers.Commands;
 using GlazeWM.Domain.Monitors;
@@ -7,7 +6,6 @@ using GlazeWM.Domain.UserConfigs;
 using GlazeWM.Domain.Windows.Commands;
 using GlazeWM.Domain.Workspaces;
 using GlazeWM.Infrastructure.Bussing;
-using GlazeWM.Infrastructure.WindowsApi;
 using static GlazeWM.Infrastructure.WindowsApi.WindowsApiService;
 
 namespace GlazeWM.Domain.Windows.CommandHandlers
@@ -65,7 +63,7 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
       // Create the window instance.
       var window = new TilingWindow(command.WindowHandle, floatingPlacement);
 
-      var matchingWindowRules = GetMatchingWindowRules(window);
+      var matchingWindowRules = _userConfigService.GetMatchingWindowRules(window);
 
       var commandStrings = matchingWindowRules
         .SelectMany(rule => rule.CommandList)
@@ -119,25 +117,6 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
         return (focusedContainer as Workspace, 0);
 
       return (focusedContainer.Parent as SplitContainer, focusedContainer.Index + 1);
-    }
-
-    private List<WindowRuleConfig> GetMatchingWindowRules(Window window)
-    {
-      return _userConfigService.UserConfig.WindowRules
-        .Where(rule =>
-        {
-          if (rule.ProcessNameRegex != null && !rule.ProcessNameRegex.IsMatch(window.ProcessName))
-            return false;
-
-          if (rule.ClassNameRegex != null && !rule.ClassNameRegex.IsMatch(window.ClassName))
-            return false;
-
-          if (rule.TitleRegex != null && !rule.TitleRegex.IsMatch(window.Title))
-            return false;
-
-          return true;
-        })
-        .ToList();
     }
   }
 }

--- a/GlazeWM.Domain/Windows/CommandHandlers/ResizeFocusedWindowBorderHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/ResizeFocusedWindowBorderHandler.cs
@@ -2,6 +2,7 @@
 using GlazeWM.Domain.Containers.Commands;
 using GlazeWM.Domain.Windows.Commands;
 using GlazeWM.Infrastructure.Bussing;
+using GlazeWM.Infrastructure.WindowsApi;
 
 namespace GlazeWM.Domain.Windows.CommandHandlers
 {
@@ -18,18 +19,27 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
 
     public CommandResponse Handle(ResizeFocusedWindowBordersCommand command)
     {
+      var borderDelta = command.ResizeDimensions;
       var focusedWindow = _containerService.FocusedContainer as Window;
 
       // Ignore cases where focused container is not a window.
       if (focusedWindow == null)
         return CommandResponse.Ok;
 
-      // Only redraw the window if it's tiling.
-      if (focusedWindow is TilingWindow)
+      focusedWindow.InvisibleBorders = new WindowRect()
       {
-        _containerService.ContainersToRedraw.Add(focusedWindow);
-        _bus.Invoke(new RedrawContainersCommand());
-      }
+        Left = focusedWindow.InvisibleBorders.Left + borderDelta.DeltaLeft,
+        Right = focusedWindow.InvisibleBorders.Right + borderDelta.DeltaRight,
+        Top = focusedWindow.InvisibleBorders.Top + borderDelta.DeltaTop,
+        Bottom = focusedWindow.InvisibleBorders.Bottom + borderDelta.DeltaBottom,
+      };
+
+      if (!(focusedWindow is TilingWindow))
+        return CommandResponse.Ok;
+
+      // Only redraw the window if it's tiling.
+      _containerService.ContainersToRedraw.Add(focusedWindow);
+      _bus.Invoke(new RedrawContainersCommand());
 
       return CommandResponse.Ok;
     }

--- a/GlazeWM.Domain/Windows/CommandHandlers/ResizeFocusedWindowBorderHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/ResizeFocusedWindowBorderHandler.cs
@@ -1,0 +1,37 @@
+﻿using GlazeWM.Domain.Containers;
+using GlazeWM.Domain.Containers.Commands;
+using GlazeWM.Domain.Windows.Commands;
+using GlazeWM.Infrastructure.Bussing;
+
+namespace GlazeWM.Domain.Windows.CommandHandlers
+{
+  class ResizeFocusedWindowBorderHandler : ICommandHandler<ResizeFocusedWindowBordersCommand>
+  {
+    private readonly Bus _bus;
+    private readonly ContainerService _containerService;
+
+    public ResizeFocusedWindowBorderHandler(Bus bus, ContainerService containerService)
+    {
+      _bus = bus;
+      _containerService = containerService;
+    }
+
+    public CommandResponse Handle(ResizeFocusedWindowBordersCommand command)
+    {
+      var focusedWindow = _containerService.FocusedContainer as Window;
+
+      // Ignore cases where focused container is not a window.
+      if (focusedWindow == null)
+        return CommandResponse.Ok;
+
+      // Only redraw the window if it's tiling.
+      if (focusedWindow is TilingWindow)
+      {
+        _containerService.ContainersToRedraw.Add(focusedWindow);
+        _bus.Invoke(new RedrawContainersCommand());
+      }
+
+      return CommandResponse.Ok;
+    }
+  }
+}

--- a/GlazeWM.Domain/Windows/CommandHandlers/ResizeFocusedWindowBordersHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/ResizeFocusedWindowBordersHandler.cs
@@ -6,12 +6,12 @@ using GlazeWM.Infrastructure.WindowsApi;
 
 namespace GlazeWM.Domain.Windows.CommandHandlers
 {
-  class ResizeFocusedWindowBorderHandler : ICommandHandler<ResizeFocusedWindowBordersCommand>
+  class ResizeFocusedWindowBordersHandler : ICommandHandler<ResizeFocusedWindowBordersCommand>
   {
     private readonly Bus _bus;
     private readonly ContainerService _containerService;
 
-    public ResizeFocusedWindowBorderHandler(Bus bus, ContainerService containerService)
+    public ResizeFocusedWindowBordersHandler(Bus bus, ContainerService containerService)
     {
       _bus = bus;
       _containerService = containerService;

--- a/GlazeWM.Domain/Windows/CommandHandlers/ResizeFocusedWindowBordersHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/ResizeFocusedWindowBordersHandler.cs
@@ -19,20 +19,20 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
 
     public CommandResponse Handle(ResizeFocusedWindowBordersCommand command)
     {
-      var borderDelta = command.ResizeDimensions;
+      var borderDelta = command.BorderDelta;
       var focusedWindow = _containerService.FocusedContainer as Window;
 
       // Ignore cases where focused container is not a window.
       if (focusedWindow == null)
         return CommandResponse.Ok;
 
-      focusedWindow.InvisibleBorders = new WindowRect()
-      {
-        Left = focusedWindow.InvisibleBorders.Left + borderDelta.DeltaLeft,
-        Right = focusedWindow.InvisibleBorders.Right + borderDelta.DeltaRight,
-        Top = focusedWindow.InvisibleBorders.Top + borderDelta.DeltaTop,
-        Bottom = focusedWindow.InvisibleBorders.Bottom + borderDelta.DeltaBottom,
-      };
+      // Adjust the existing border delta of the window.
+      focusedWindow.BorderDelta = new RectDelta(
+        focusedWindow.BorderDelta.DeltaLeft + borderDelta.DeltaLeft,
+        focusedWindow.BorderDelta.DeltaTop + borderDelta.DeltaTop,
+        focusedWindow.BorderDelta.DeltaRight + borderDelta.DeltaRight,
+        focusedWindow.BorderDelta.DeltaBottom + borderDelta.DeltaBottom
+      );
 
       if (!(focusedWindow is TilingWindow))
         return CommandResponse.Ok;

--- a/GlazeWM.Domain/Windows/Commands/ResizeFocusedWindowBordersCommand.cs
+++ b/GlazeWM.Domain/Windows/Commands/ResizeFocusedWindowBordersCommand.cs
@@ -5,12 +5,11 @@ namespace GlazeWM.Domain.Windows.Commands
 {
   public class ResizeFocusedWindowBordersCommand : Command
   {
-    // TODO: Alternate names: ResizeDelta.
-    public RectDelta ResizeDimensions { get; }
+    public RectDelta BorderDelta { get; }
 
-    public ResizeFocusedWindowBordersCommand(RectDelta resizeRect)
+    public ResizeFocusedWindowBordersCommand(RectDelta borderDelta)
     {
-      ResizeDimensions = resizeRect;
+      BorderDelta = borderDelta;
     }
   }
 }

--- a/GlazeWM.Domain/Windows/Commands/ResizeFocusedWindowBordersCommand.cs
+++ b/GlazeWM.Domain/Windows/Commands/ResizeFocusedWindowBordersCommand.cs
@@ -1,15 +1,16 @@
 ﻿using GlazeWM.Infrastructure.Bussing;
-using System;
+using GlazeWM.Infrastructure.WindowsApi;
 
 namespace GlazeWM.Domain.Windows.Commands
 {
   public class ResizeFocusedWindowBordersCommand : Command
   {
-    public IntPtr WindowHandle { get; }
+    // TODO: Alternate names: ResizeDelta.
+    public RectDelta ResizeDimensions { get; }
 
-    public ResizeFocusedWindowBordersCommand(IntPtr windowHandle)
+    public ResizeFocusedWindowBordersCommand(RectDelta resizeRect)
     {
-      WindowHandle = windowHandle;
+      ResizeDimensions = resizeRect;
     }
   }
 }

--- a/GlazeWM.Domain/Windows/Commands/ResizeFocusedWindowBordersCommand.cs
+++ b/GlazeWM.Domain/Windows/Commands/ResizeFocusedWindowBordersCommand.cs
@@ -1,0 +1,15 @@
+﻿using GlazeWM.Infrastructure.Bussing;
+using System;
+
+namespace GlazeWM.Domain.Windows.Commands
+{
+  public class ResizeFocusedWindowBordersCommand : Command
+  {
+    public IntPtr WindowHandle { get; }
+
+    public ResizeFocusedWindowBordersCommand(IntPtr windowHandle)
+    {
+      WindowHandle = windowHandle;
+    }
+  }
+}

--- a/GlazeWM.Domain/Windows/Window.cs
+++ b/GlazeWM.Domain/Windows/Window.cs
@@ -23,6 +23,18 @@ namespace GlazeWM.Domain.Windows
     /// </summary>
     public bool HasPendingDpiAdjustment { get; set; } = false;
 
+    /// <summary>
+    /// Windows typically have a 1px visible border and a 7px invisible border on the left, right,
+    /// and bottom edges. This needs to be adjusted for to draw a window with exact dimensions.
+    /// </summary>
+    public WindowRect InvisibleBorders { get; set; } = new WindowRect
+    {
+      Left = 7,
+      Right = 7,
+      Top = 0,
+      Bottom = 7,
+    };
+
     private WindowService _windowService = ServiceLocator.Provider.GetRequiredService<WindowService>();
     private WorkspaceService _workspaceService = ServiceLocator.Provider.GetRequiredService<WorkspaceService>();
 

--- a/GlazeWM.Domain/Windows/Window.cs
+++ b/GlazeWM.Domain/Windows/Window.cs
@@ -24,16 +24,11 @@ namespace GlazeWM.Domain.Windows
     public bool HasPendingDpiAdjustment { get; set; } = false;
 
     /// <summary>
-    /// Windows typically have a 1px visible border and a 7px invisible border on the left, right,
-    /// and bottom edges. This needs to be adjusted for to draw a window with exact dimensions.
+    /// The difference in window dimensions to adjust for invisible borders. This is typically 7px
+    /// on the left, right, and bottom edges. This needs to be adjusted for to draw a window with
+    /// exact dimensions.
     /// </summary>
-    public WindowRect InvisibleBorders { get; set; } = new WindowRect
-    {
-      Left = 7,
-      Right = 7,
-      Top = 0,
-      Bottom = 7,
-    };
+    public RectDelta BorderDelta { get; set; } = new RectDelta(7, 0, 7, 7);
 
     private WindowService _windowService = ServiceLocator.Provider.GetRequiredService<WindowService>();
     private WorkspaceService _workspaceService = ServiceLocator.Provider.GetRequiredService<WorkspaceService>();

--- a/GlazeWM.Infrastructure/Utils/UnitsHelper.cs
+++ b/GlazeWM.Infrastructure/Utils/UnitsHelper.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace GlazeWM.Infrastructure.Utils
+{
+  public static class UnitsHelper
+  {
+    public static int TrimUnits(string amountWithUnits)
+    {
+      var unitsRegex = new Regex(@"(%|ppt|px)");
+      var amount = unitsRegex.Replace(amountWithUnits, "").Trim();
+      return Convert.ToInt32(amount, CultureInfo.InvariantCulture);
+    }
+  }
+}

--- a/GlazeWM.Infrastructure/WindowsApi/RectDelta.cs
+++ b/GlazeWM.Infrastructure/WindowsApi/RectDelta.cs
@@ -1,0 +1,33 @@
+﻿namespace GlazeWM.Infrastructure.WindowsApi
+{
+  public class RectDelta
+  {
+    /// <summary>
+    /// The difference in x-coordinates of the upper-left corner of the rectangle.
+    /// </summary>
+    public int DeltaLeft { get; }
+
+    /// <summary>
+    /// The difference in y-coordinates of the upper-left corner of the rectangle.
+    /// </summary>
+    public int DeltaTop { get; }
+
+    /// <summary>
+    /// The difference in x-coordinates of the lower-right corner of the rectangle.
+    /// </summary>
+    public int DeltaRight { get; }
+
+    /// <summary>
+    /// The difference in y-coordinates of the lower-right corner of the rectangle.
+    /// </summary>
+    public int DeltaBottom { get; }
+
+    public RectDelta(int deltaLeft, int deltaTop, int deltaRight, int deltaBottom)
+    {
+      DeltaLeft = deltaLeft;
+      DeltaRight = deltaRight;
+      DeltaTop = deltaTop;
+      DeltaBottom = deltaBottom;
+    }
+  }
+}

--- a/GlazeWM.Infrastructure/WindowsApi/WindowRect.cs
+++ b/GlazeWM.Infrastructure/WindowsApi/WindowRect.cs
@@ -30,16 +30,37 @@
 
     public int Height => Bottom - Top;
 
+    /// <summary>
+    /// Creates a new `WindowRect` from coordinates of its upper-left and lower-right corners.
+    /// </summary>
+    public static WindowRect FromLTRB(int left, int top, int right, int bottom)
+    {
+      return new WindowRect()
+      {
+        Left = left,
+        Right = right,
+        Top = top,
+        Bottom = bottom,
+      };
+    }
+
+    /// <summary>
+    /// Creates a new `WindowRect` from its X/Y coordinates and size.
+    /// </summary>
+    public static WindowRect FromXYCoordinates(int x, int y, int width, int height)
+    {
+      return new WindowRect()
+      {
+        Left = x,
+        Right = x + width,
+        Top = y,
+        Bottom = y + height,
+      };
+    }
+
     public WindowRect TranslateToCoordinates(int x, int y)
     {
-      var translatedRect = new WindowRect();
-
-      translatedRect.Left = x;
-      translatedRect.Right = x + Width;
-      translatedRect.Top = y;
-      translatedRect.Bottom = y + Height;
-
-      return translatedRect;
+      return FromXYCoordinates(x, y, Width, Height);
     }
 
     public WindowRect TranslateToCenter(WindowRect outerRect)


### PR DESCRIPTION
* Most windows have a 7px invisible border on the left, right, and bottom edges. This means that even when users have 0px gaps in their configuration, there are still apparent gaps between windows (see #33). To adjust for this, increase window size when tiling by 7px on the left, right, and bottom.
* Electron apps do not have a 7px invisible border and are thus over-corrected by the fix mentioned above. To accommodate for such apps, a `resize borders <PX_DELTA> <PX_DELTA> <PX_DELTA> <PX_DELTA>` command was added.

Closes #33.