### PR TITLE
feat: avoid managing menu windows

### DIFF
--- a/GlazeWM.Domain/Windows/WindowService.cs
+++ b/GlazeWM.Domain/Windows/WindowService.cs
@@ -159,6 +159,15 @@ namespace GlazeWM.Domain.Windows
       if (!isApplicationWindow)
         return false;
 
+      /// Some applications spawn top-level windows for menus that should be ignored. This includes
+      /// the autocomplete popup in Notepad++ and title bar menu in Keepass. Although not
+      /// foolproof, these can typically be identified by having an owner window and no title bar.
+      var isMenuWindow = GetWindow(handle, GW.GW_OWNER) != IntPtr.Zero
+        && !HandleHasWindowStyle(handle, WS.WS_CAPTION);
+
+      if (isMenuWindow)
+        return false;
+
       return true;
     }
 

--- a/GlazeWM.Domain/Windows/WindowService.cs
+++ b/GlazeWM.Domain/Windows/WindowService.cs
@@ -159,12 +159,6 @@ namespace GlazeWM.Domain.Windows
       if (!isApplicationWindow)
         return false;
 
-      // Get whether the window belongs to the current process.
-      var isCurrentProcess = GetProcessOfHandle(handle).Id == Process.GetCurrentProcess().Id;
-
-      if (isCurrentProcess)
-        return false;
-
       return true;
     }
 


### PR DESCRIPTION
* Avoid managing windows that are likely to be application menu windows (eg. Notepad++ autocomplete popup and title bar menu in Keepass). These windows are identified by having an owner window and no `WS_CAPTION` window style.

Closes #61 and #57