### PR TITLE
feat: respect initial minimized state

### DIFF
--- a/GlazeWM.Domain/Windows/CommandHandlers/ToggleFloatingHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/ToggleFloatingHandler.cs
@@ -39,7 +39,10 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
       // Keep reference to the window's ancestor workspace prior to detaching.
       var workspace = _workspaceService.GetWorkspaceFromChildContainer(window);
 
-      _bus.Invoke(new MoveContainerWithinTreeCommand(window, workspace, true));
+      if (window is IResizable)
+        _bus.Invoke(new MoveContainerWithinTreeCommand(window, workspace, true));
+      else
+        _bus.Invoke(new MoveContainerWithinTreeCommand(window, workspace, false));
 
       // Create a floating window and place it in the center of the workspace.
       var floatingWindow = new FloatingWindow(

--- a/GlazeWM.Domain/Workspaces/CommandHandlers/MoveFocusedWindowToWorkspaceHandler.cs
+++ b/GlazeWM.Domain/Workspaces/CommandHandlers/MoveFocusedWindowToWorkspaceHandler.cs
@@ -50,11 +50,10 @@ namespace GlazeWM.Domain.Workspaces.CommandHandlers
         focusedWindow.FloatingPlacement =
           focusedWindow.FloatingPlacement.TranslateToCenter(targetWorkspace.ToRectangle());
 
-      if (focusedWindow is FloatingWindow)
-        _bus.Invoke(new MoveContainerWithinTreeCommand(focusedWindow, targetWorkspace, false));
-
-      else
+      if (focusedWindow is TilingWindow)
         MoveTilingWindowToWorkspace(focusedWindow as TilingWindow, targetWorkspace);
+      else
+        _bus.Invoke(new MoveContainerWithinTreeCommand(focusedWindow, targetWorkspace, false));
 
       // Reassign focus to descendant within the current workspace.
       _bus.Invoke(new FocusWorkspaceCommand(currentWorkspace.Name));


### PR DESCRIPTION
* When the WM is launched, retain minimized windows in their minimized state (instead of restoring them to be tiling). 

Closes #56 