### PR TITLE
bug: When opening windows terminal, GlazeWM sometimes crashes

### DIFF
--- a/GlazeWM.Domain/Windows/Window.cs
+++ b/GlazeWM.Domain/Windows/Window.cs
@@ -40,7 +40,7 @@ namespace GlazeWM.Domain.Windows
     /// </summary>
     public bool IsHidden => !WorkspaceService.GetWorkspaceFromChildContainer(this).IsDisplayed;
 
-    public string ProcessName => WindowService.GetProcessOfHandle(Hwnd).ProcessName;
+    public string ProcessName => WindowService.GetProcessOfHandle(Hwnd)?.ProcessName ?? string.Empty;
 
     public string ClassName => WindowService.GetClassNameOfHandle(Hwnd);
 


### PR DESCRIPTION
When I open a windows terminal instance using Windows -> Run, GlazeWM crashes.

I've found in the `errors.log` file:

```
21/06/2022 8:56:32 am
Object reference not set to an instance of an object.   at GlazeWM.Domain.Windows.Window.get_ProcessName() in C:\Projects.GitHub\GlazeWM\GlazeWM.Domain\Windows\Window.cs:line 43
   at GlazeWM.Domain.UserConfigs.UserConfigService.<>c__DisplayClass9_0.<GetMatchingWindowRules>b__0(WindowRuleConfig rule) in C:\Projects.GitHub\GlazeWM\GlazeWM.Domain\UserConfigs\UserConfigService.cs:line 136
   at System.Linq.Enumerable.WhereListIterator`1.MoveNext()
   at System.Linq.Enumerable.SelectManySingleSelectorIterator`2.MoveNext()
   at System.Linq.Enumerable.SelectEnumerableIterator`2.MoveNext()
   at System.Linq.Enumerable.Contains[TSource](IEnumerable`1 source, TSource value, IEqualityComparer`1 comparer)
   at GlazeWM.Domain.Windows.CommandHandlers.AddWindowHandler.Handle(AddWindowCommand command) in C:\Projects.GitHub\GlazeWM\GlazeWM.Domain\Windows\CommandHandlers\AddWindowHandler.cs:line 71
   at GlazeWM.Infrastructure.Bussing.Bus.Invoke[T](T command) in C:\Projects.GitHub\GlazeWM\GlazeWM.Infrastructure\Bussing\Bus.cs:line 44
   at GlazeWM.Domain.Windows.EventHandlers.WindowShownHandler.Handle(WindowShownEvent event) in C:\Projects.GitHub\GlazeWM\GlazeWM.Domain\Windows\EventHandlers\WindowShownHandler.cs:line 38
   at GlazeWM.Infrastructure.Bussing.Bus.RaiseEvent[T](T event) in C:\Projects.GitHub\GlazeWM\GlazeWM.Infrastructure\Bussing\Bus.cs:line 71

```


To resolve this, I've actually just done a `null` check and return `string.Empty`.  That has solved the problem for me, but I'm not sure if that's how you'd want to solve it.  

Here is the PR anyway.

Regards,