### PR TITLE
bug: Added code to make sure that the keys pressed matches the keybind exactly

### DIFF
--- a/GlazeWM.Infrastructure/WindowsApi/KeybindingService.cs
+++ b/GlazeWM.Infrastructure/WindowsApi/KeybindingService.cs
@@ -100,6 +100,33 @@ namespace GlazeWM.Infrastructure.WindowsApi
 
       var matchedKeybindings = registeredKeybindings.Where(keybinding =>
       {
+        // This makes sure that if you press Control+Alt+1, and you have a keybinding of Alt+1, that
+        // it doesn't fire, even though that all the keys satisfy it, the event has too many keys,
+        // so it shouldn't fire.
+        // var modifiers = new Keys[] { Keys.LControlKey, Keys.RControlKey, Keys.LMenu, Keys.RMenu, Keys.LShiftKey, Keys.RShiftKey };
+        // foreach (Keys m in modifiers)
+        // {
+        //   if (!keybinding.KeyCombination.Contains(m) && IsKeyDown(m))
+        //   {
+        //     return false;
+        //   }
+        // }
+
+        if (!keybinding.KeyCombination.Contains(Keys.Control) && (IsKeyDown(Keys.LControlKey) || IsKeyDown(Keys.RControlKey)))
+        {
+          return false;
+        }
+
+        if (!keybinding.KeyCombination.Contains(Keys.Alt) && (IsKeyDown(Keys.LMenu) || IsKeyDown(Keys.RMenu)))
+        {
+          return false;
+        }
+
+        if (!keybinding.KeyCombination.Contains(Keys.Shift) && (IsKeyDown(Keys.LShiftKey) || IsKeyDown(Keys.RShiftKey)))
+        {
+          return false;
+        }
+
         return keybinding.KeyCombination.All(key =>
         {
           if (key == pressedKey)


### PR DESCRIPTION
This resolves the issue where a keybind has less keys than the keys that were pressed.

E.g. when you have a keybind of `Alt+1`, but you press `Control+Alt+1`, it still fired.  It should NOT fire it, because you didn't press exactly `Alt+1`.

I had a problem where I have `Control+Alt+1` bound in another application and Glaze hijacked the keybinding, despite my config only being `Alt+1`.

Let me know if this is fine, or if there is a better way to handle this.

Cheers,