### PR TITLE
feat: resize windows with sizing border

### DIFF
--- a/GlazeWM.Domain/Containers/CommandHandlers/AttachAndResizeContainerHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/AttachAndResizeContainerHandler.cs
@@ -25,7 +25,7 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
 
       _bus.Invoke(new AttachContainerCommand(childToAdd, targetParent, targetIndex));
 
-      var resizableSiblings = childToAdd.Siblings.Where(container => container is IResizable);
+      var resizableSiblings = childToAdd.SiblingsOfType(typeof(IResizable));
 
       var defaultPercent = 1.0 / (resizableSiblings.Count() + 1);
       (childToAdd as IResizable).SizePercentage = defaultPercent;

--- a/GlazeWM.Domain/Containers/Container.cs
+++ b/GlazeWM.Domain/Containers/Container.cs
@@ -136,6 +136,11 @@ namespace GlazeWM.Domain.Containers
       return Children.Where(container => type.IsAssignableFrom(container.GetType()));
     }
 
+    public IEnumerable<Container> SiblingsOfType(Type type)
+    {
+      return Siblings.Where(container => type.IsAssignableFrom(container.GetType()));
+    }
+
     public IEnumerable<Container> SelfAndSiblingsOfType(Type type)
     {
       return SelfAndSiblings.Where(container => type.IsAssignableFrom(container.GetType()));

--- a/GlazeWM.Domain/Windows/CommandHandlers/ResizeWindowHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/ResizeWindowHandler.cs
@@ -5,7 +5,6 @@ using System.Text.RegularExpressions;
 using GlazeWM.Domain.Common.Enums;
 using GlazeWM.Domain.Containers;
 using GlazeWM.Domain.Containers.Commands;
-using GlazeWM.Domain.Monitors;
 using GlazeWM.Domain.Windows.Commands;
 using GlazeWM.Domain.Workspaces;
 using GlazeWM.Infrastructure.Bussing;
@@ -69,9 +68,15 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
     {
       var parentWorkspace = WorkspaceService.GetWorkspaceFromChildContainer(windowToResize);
 
+      // Get workspace width and height excluding inner gaps.
+      var occupiedWidth =
+        parentWorkspace.Children.Aggregate(0, (width, child) => width + child.Width);
+      var occupiedHeight =
+        parentWorkspace.Children.Aggregate(0, (height, child) => height + child.Height);
+
       return dimensionToResize == ResizeDimension.WIDTH
-        ? 1.0 / parentWorkspace.Width
-        : 1.0 / parentWorkspace.Height;
+        ? 1.0 / occupiedWidth
+        : 1.0 / occupiedHeight;
     }
 
     private static double ConvertToResizeProportion(string resizeAmount, double scaleFactor)

--- a/GlazeWM.Domain/Windows/EventHandlers/WindowMovedOrResizedHandler.cs
+++ b/GlazeWM.Domain/Windows/EventHandlers/WindowMovedOrResizedHandler.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using GlazeWM.Domain.Common.Enums;
 using GlazeWM.Domain.Common.Utils;
+using GlazeWM.Domain.Containers;
 using GlazeWM.Domain.Containers.Commands;
 using GlazeWM.Domain.Containers.Events;
 using GlazeWM.Domain.Monitors;
@@ -18,19 +19,22 @@ namespace GlazeWM.Domain.Windows.EventHandlers
     private readonly Bus _bus;
     private readonly WindowService _windowService;
     private readonly MonitorService _monitorService;
+    private readonly ContainerService _containerService;
     private readonly ILogger<WindowMovedOrResizedHandler> _logger;
 
     public WindowMovedOrResizedHandler(
       Bus bus,
       WindowService windowService,
       MonitorService monitorService,
-      ILogger<WindowMovedOrResizedHandler> logger
+      ILogger<WindowMovedOrResizedHandler> logger,
+      ContainerService containerService
     )
     {
       _bus = bus;
       _windowService = windowService;
       _monitorService = monitorService;
       _logger = logger;
+      _containerService = containerService;
     }
 
     public void Handle(WindowMovedOrResizedEvent @event)
@@ -55,9 +59,19 @@ namespace GlazeWM.Domain.Windows.EventHandlers
 
     private void UpdateTilingWindow(TilingWindow window)
     {
-      var currentPlacement = WindowService.GetPlacementOfHandle(window.Hwnd).NormalPosition;
+      // Snap window to its original position even if it's not being resized.
+      var hasNoResizableSiblings = window.Parent is Workspace
+        && !window.SiblingsOfType(typeof(IResizable)).Any();
+
+      if (hasNoResizableSiblings)
+      {
+        _containerService.ContainersToRedraw.Add(window);
+        _bus.Invoke(new RedrawContainersCommand());
+        return;
+      }
 
       // Remove invisible borders from current placement to be able to compare window width/height.
+      var currentPlacement = WindowService.GetPlacementOfHandle(window.Hwnd).NormalPosition;
       var adjustedPlacement = new WindowRect
       {
         Left = currentPlacement.Left + window.BorderDelta.DeltaLeft,
@@ -70,7 +84,6 @@ namespace GlazeWM.Domain.Windows.EventHandlers
       var deltaHeight = adjustedPlacement.Height - window.Height;
 
       // TODO: Avoid unnecessary resize call if either delta is 0.
-      // TODO: Window does not snap back to original position when there are no sibling windows.
       _bus.Invoke(new ResizeWindowCommand(window, ResizeDimension.WIDTH, $"{deltaWidth}px"));
       _bus.Invoke(new ResizeWindowCommand(window, ResizeDimension.HEIGHT, $"{deltaHeight}px"));
     }

--- a/GlazeWM.Domain/Windows/EventHandlers/WindowMovedOrResizedHandler.cs
+++ b/GlazeWM.Domain/Windows/EventHandlers/WindowMovedOrResizedHandler.cs
@@ -57,14 +57,12 @@ namespace GlazeWM.Domain.Windows.EventHandlers
     {
       var currentPlacement = WindowService.GetPlacementOfHandle(window.Hwnd).NormalPosition;
 
-      var resizeDimension = (window.Parent as SplitContainer).Layout == Layout.HORIZONTAL
-        ? ResizeDimension.WIDTH
-        : ResizeDimension.HEIGHT;
-      var resizeAmount = resizeDimension == ResizeDimension.WIDTH
-        ? $"{currentPlacement.Width - window.Width}px"
-        : $"{currentPlacement.Height - window.Height}px";
+      // TODO: Add correct border delta.
+      var deltaWidth = currentPlacement.Width - window.Width + window.BorderDelta.DeltaLeft;
+      var deltaHeight = currentPlacement.Height - window.Height + window.BorderDelta.DeltaLeft;
 
-      _bus.Invoke(new ResizeWindowCommand(window, resizeDimension, resizeAmount));
+      _bus.Invoke(new ResizeWindowCommand(window, ResizeDimension.WIDTH, $"{deltaWidth}px"));
+      _bus.Invoke(new ResizeWindowCommand(window, ResizeDimension.HEIGHT, $"{deltaHeight}px"));
     }
 
     private void UpdateFloatingWindow(FloatingWindow window)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Why use a tiling window manager? A tiling WM lets you easily organize windows an
 - Simple YAML configuration
 - Multi-monitor support
 - Customizable bar window
-- Handles monitor connections & disconnections
 - Customizable rules for specific windows
+- Easy one-click installation
 
 ![demo](https://user-images.githubusercontent.com/34844898/142960922-fb3abd0d-082c-4f92-8613-865c68006bd8.gif)
 
@@ -30,7 +30,7 @@ To build for other runtimes than Windows x64, see [here](https://docs.microsoft.
 
 - Improve handling of fullscreen and maximized windows.
 - More bar components.
-- Change the size of sibling windows when a tiling window is resized with the sizing border.
+- Reload user config without restarting WM.
 
 # Configuration
 


### PR DESCRIPTION
* Be able to drag the sizing border of a window to resize a window. If a window is the only container in a workspace, this snaps the window back to its original position.