### PR TITLE
feat: Allow change of config file location via command line args

### DIFF
--- a/GlazeWM.Bootstrapper/Program.cs
+++ b/GlazeWM.Bootstrapper/Program.cs
@@ -7,9 +7,11 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Windows.Forms;
+using Microsoft.Extensions.Configuration;
 
 namespace GlazeWM.Bootstrapper
 {
@@ -21,7 +23,7 @@ namespace GlazeWM.Bootstrapper
     ///  The main entry point for the application.
     /// </summary>
     [STAThread]
-    private static void Main()
+    private static void Main(string[] args)
     {
       Debug.WriteLine("Application started.");
 
@@ -35,7 +37,7 @@ namespace GlazeWM.Bootstrapper
         return;
       }
 
-      var host = CreateHost();
+      var host = CreateHost(args);
       ServiceLocator.Provider = host.Services;
 
       var startup = ServiceLocator.Provider.GetRequiredService<Startup>();
@@ -43,9 +45,16 @@ namespace GlazeWM.Bootstrapper
       Application.Run();
     }
 
-    private static IHost CreateHost()
+    private static IHost CreateHost(string[] args)
     {
       return Host.CreateDefaultBuilder()
+        .ConfigureAppConfiguration(appConfig =>
+        {
+          appConfig.AddCommandLine(args, new Dictionary<string, string>
+          {
+            {"--config", "UserConfigPath"}
+          });
+        })
         .ConfigureServices((_, services) =>
         {
           services.AddInfrastructureServices();

--- a/GlazeWM.Domain/UserConfigs/CommandHandlers/EvaluateUserConfigHandler.cs
+++ b/GlazeWM.Domain/UserConfigs/CommandHandlers/EvaluateUserConfigHandler.cs
@@ -60,7 +60,7 @@ namespace GlazeWM.Domain.UserConfigs.CommandHandlers
     private static void InitializeSampleUserConfig(string userConfigPath)
     {
       // Fix any inconsistencies in directory delimiters.
-      var normalizedUserConfigPath = Path.GetFullPath(new Uri(userConfigPath).LocalPath);
+      var normalizedUserConfigPath = new FileInfo(userConfigPath).FullName;
 
       var promptResult = MessageBox.Show(
         $"No config file found at {normalizedUserConfigPath}. Create a new config file from the starter template?",

--- a/GlazeWM.Domain/UserConfigs/UserConfigService.cs
+++ b/GlazeWM.Domain/UserConfigs/UserConfigService.cs
@@ -13,10 +13,15 @@ namespace GlazeWM.Domain.UserConfigs
     /// <summary>
     /// Path to the user's config file.
     /// </summary>
-    public string UserConfigPath = Path.Combine(
-      Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-      "./.glaze-wm/config.yaml"
-    );
+    public string UserConfigPath
+    {
+      get
+      {
+        var args = Environment.GetCommandLineArgs();
+        // argument 0 is the programs path
+        return args.Length > 1 ? args[1] : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "./.glaze-wm/config.yaml");
+      }
+    } 
 
     public readonly List<WindowRuleConfig> DefaultWindowRules = GetDefaultWindowRules();
 

--- a/GlazeWM.Domain/UserConfigs/UserConfigService.cs
+++ b/GlazeWM.Domain/UserConfigs/UserConfigService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using GlazeWM.Domain.Windows;
+using Microsoft.Extensions.Configuration;
 
 namespace GlazeWM.Domain.UserConfigs
 {
@@ -13,15 +14,19 @@ namespace GlazeWM.Domain.UserConfigs
     /// <summary>
     /// Path to the user's config file.
     /// </summary>
-    public string UserConfigPath
+    public string UserConfigPath => _configuration.GetValue<string>("UserConfigPath") ?? _defaultUserConfigPath;
+    
+    private readonly string _defaultUserConfigPath = Path.Combine(
+      Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+      "./.glaze-wm/config.yaml"
+    );
+
+    private readonly IConfiguration _configuration;
+    
+    public UserConfigService(IConfiguration configuration)
     {
-      get
-      {
-        var args = Environment.GetCommandLineArgs();
-        // argument 0 is the programs path
-        return args.Length > 1 ? args[1] : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "./.glaze-wm/config.yaml");
-      }
-    } 
+      _configuration = configuration;
+    }
 
     public readonly List<WindowRuleConfig> DefaultWindowRules = GetDefaultWindowRules();
 


### PR DESCRIPTION
Hey!

@stewart-james asked in #41 for allowing to load a different config file, so I quickly threw together this PR. 

`new FileInfo(path).FullName` is a good replacement for the URI thing as that allows relative file paths as well.