### PR TITLE
bug: Fix #115 - Workspace name missalignment

### DIFF
--- a/GlazeWM.Bar/Components/WorkspacesComponent.xaml
+++ b/GlazeWM.Bar/Components/WorkspacesComponent.xaml
@@ -19,6 +19,7 @@
         <Button
           x:Name="WorkspaceButton"
           Content="{Binding DisplayName}"
+          VerticalAlignment="Center"
           Command="{Binding DataContext.FocusWorkspaceCommand, ElementName=_workspacesComponent}"
           CommandParameter="{Binding Name}"
           Background="{Binding DataContext.DefaultWorkspaceBackground, ElementName=_workspacesComponent}"

--- a/GlazeWM.Bar/Components/WorkspacesComponent.xaml
+++ b/GlazeWM.Bar/Components/WorkspacesComponent.xaml
@@ -29,8 +29,8 @@
           FontWeight="{Binding DataContext.FontWeight, ElementName=_workspacesComponent}"
           FontSize="{Binding DataContext.FontSize, ElementName=_workspacesComponent}"
           BorderThickness="{Binding DataContext.DefaultWorkspaceBorderWidth, ElementName=_workspacesComponent}"
-          MinWidth="{Binding ActualHeight, RelativeSource={RelativeSource Self}}"
-          MinHeight="{Binding ActualWidth, RelativeSource={RelativeSource Self}}"
+          MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource Self}}"
+          MinHeight="{Binding ActualHeight, RelativeSource={RelativeSource Self}}"
           Cursor="Hand" />
 
         <DataTemplate.Triggers>


### PR DESCRIPTION
Hey there!

This is a very quick fix which should fix #115:
![image](https://user-images.githubusercontent.com/11274700/188446006-17f72bfd-7484-4c79-8929-4c3f1f72c2f7.png)
