### PR TITLE
feat: improvements to `exec` command

### DIFF
--- a/GlazeWM.Domain/Common/CommandHandlers/ExecProcessHandler.cs
+++ b/GlazeWM.Domain/Common/CommandHandlers/ExecProcessHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Windows.Forms;
 using GlazeWM.Domain.Common.Commands;
 using GlazeWM.Infrastructure.Bussing;
 
@@ -21,17 +22,17 @@ namespace GlazeWM.Domain.Common.CommandHandlers
           FileName = Environment.ExpandEnvironmentVariables(processName),
           Arguments = string.Join(" ", args),
           UseShellExecute = true,
-          ErrorDialog = true,
           // Set user profile directory as the working dir. This affects the starting directory
           // of terminal processes (eg. CMD, Git bash, etc).
           WorkingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
         };
         process.Start();
       }
-      catch (Exception e)
+      catch (Exception exception)
       {
         // TODO: Link to documentation for `exec` command (no proper documentation yet).
         // TODO: Handle non-fatal exceptions in a generic way.
+        MessageBox.Show(exception.Message);
       }
 
       return CommandResponse.Ok;

--- a/GlazeWM.Domain/Common/Commands/StartProcessCommand.cs
+++ b/GlazeWM.Domain/Common/Commands/StartProcessCommand.cs
@@ -1,13 +1,14 @@
-﻿using GlazeWM.Infrastructure.Bussing;
+﻿using System.Collections.Generic;
+using GlazeWM.Infrastructure.Bussing;
 
 namespace GlazeWM.Domain.Common.Commands
 {
   public class ExecProcessCommand : Command
   {
-    public string ProcessName { get; init; }
-    public string[] Args { get; init; }
+    public string ProcessName { get; }
+    public List<string> Args { get; }
 
-    public ExecProcessCommand(string processName, string[] args)
+    public ExecProcessCommand(string processName, List<string> args)
     {
       ProcessName = processName;
       Args = args;

--- a/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
+++ b/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
@@ -235,13 +235,13 @@ namespace GlazeWM.Domain.UserConfigs
 
     public static List<string> ExtractProcessArgs(string processNameAndArgs)
     {
-      var processName = ExtractProcessName(processNameAndArgs);
+      var hasSingleQuotes = processNameAndArgs.StartsWith("'");
 
-      return processNameAndArgs
-        .Replace($"{processName} ", "")
-        .Split(" ")
-        .Where(arg => !string.IsNullOrWhiteSpace(arg))
-        .ToList();
+      var args = hasSingleQuotes
+        ? processNameAndArgs.Split("'")[2..]
+        : processNameAndArgs.Split(" ")[1..];
+
+      return args.Where(arg => !string.IsNullOrWhiteSpace(arg)).ToList();
     }
 
     private static RectDelta ShorthandToRectDelta(string shorthand)

--- a/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
+++ b/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
@@ -202,6 +202,21 @@ namespace GlazeWM.Domain.UserConfigs
       return workspaceConfig is not null;
     }
 
+    // TODO: Either create method `ParseExecCommand`, which directly returns a `Command` instance,
+    // or alternatively create separate methods `ExtractProcessName()` and `ExtractProcessArgs`.
+    public static (string, string[]) ParseProcessNameAndArgs(string processNameAndArgs)
+    {
+      var hasSingleQuotes = processNameAndArgs.StartsWith("'");
+
+      var processName = hasSingleQuotes
+        ? processNameAndArgs.Split("'")[1]
+        : processNameAndArgs.Split(" ")[0];
+
+      var arguments = processNameAndArgs.Replace($"{processName} ", "").Split(" ");
+
+      return (processName, arguments);
+    }
+
     private static RectDelta ShorthandToRectDelta(string shorthand)
     {
       var shorthandParts = shorthand.Split(" ")

--- a/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
+++ b/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using GlazeWM.Domain.Common.Commands;
@@ -28,9 +29,29 @@ namespace GlazeWM.Domain.UserConfigs
 
     public static string FormatCommand(string commandString)
     {
-      var formattedCommandString = commandString.Trim().ToLowerInvariant();
+      var trimmedCommandString = commandString.Trim().ToLowerInvariant();
+
       var multipleSpacesRegex = new Regex(@"\s+");
-      return multipleSpacesRegex.Replace(formattedCommandString, " ");
+      var formattedCommandString = multipleSpacesRegex.Replace(trimmedCommandString, " ");
+
+      var caseSensitiveCommandRegex = new List<Regex>
+      {
+        new Regex("^(exec).*", RegexOptions.IgnoreCase),
+      };
+
+      // Some commands are partially case-sensitive (eg. `exec ...`). To handle such cases, only
+      // format part of the command string to be lowercase.
+      foreach (var regex in caseSensitiveCommandRegex)
+      {
+        if (regex.IsMatch(formattedCommandString))
+        {
+          return regex.Replace(formattedCommandString, (Match match) =>
+            match.Value.ToLowerInvariant()
+          );
+        }
+      }
+
+      return formattedCommandString.ToLowerInvariant();
     }
 
     public void ValidateCommand(string commandString)


### PR DESCRIPTION
* Avoid formatting `exec` command to lowercase (since the arguments passed to the process might be case sensitive).
* Prevent crash if there is an error when launching a process via `exec` (eg. if the executable is not found). Instead show a pop-up with the message.
* Allow paths to executables with spaces by wrapping the file path in single quotes (eg. `exec 'C:\Program Files\Git\git-bash.exe'`.
* Expand environment variables when calling `exec` with a file path (eg. `exec %ProgramFiles%\Git\git-bash.exe`).