### PR TITLE
fix: keybindings do not fire if desktop has focus

### DIFF
--- a/GlazeWM.Domain/Containers/CommandHandlers/AttachContainerHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/AttachContainerHandler.cs
@@ -19,7 +19,7 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
       var targetParent = command.TargetParent;
       var targetIndex = command.TargetIndex;
 
-      if (childToAdd.Parent != null)
+      if (!childToAdd.IsDetached())
         throw new Exception("Cannot attach an already attached container. This is a bug.");
 
       childToAdd.Parent = targetParent;

--- a/GlazeWM.Domain/Containers/CommandHandlers/ReplaceContainerHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/ReplaceContainerHandler.cs
@@ -21,7 +21,7 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
       var targetParent = command.TargetParent;
       var targetIndex = command.TargetIndex;
 
-      if (replacementContainer.Parent != null)
+      if (!replacementContainer.IsDetached())
         throw new Exception(
           "Cannot use an already attached container as replacement container. This is a bug."
         );

--- a/GlazeWM.Domain/Containers/Container.cs
+++ b/GlazeWM.Domain/Containers/Container.cs
@@ -110,6 +110,11 @@ namespace GlazeWM.Domain.Containers
       }
     }
 
+    public bool IsDetached()
+    {
+      return Parent is null;
+    }
+
     public bool HasChildren()
     {
       return Children.Count > 0;

--- a/GlazeWM.Domain/Containers/ContainerService.cs
+++ b/GlazeWM.Domain/Containers/ContainerService.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using GlazeWM.Domain.Common.Enums;
 using GlazeWM.Domain.UserConfigs;
 using GlazeWM.Domain.Windows;
-using static GlazeWM.Infrastructure.WindowsApi.WindowsApiService;
 
 namespace GlazeWM.Domain.Containers
 {
@@ -39,25 +38,6 @@ namespace GlazeWM.Domain.Containers
     /// focus window event (ie. `EVENT_SYSTEM_FOREGROUND`).
     /// </summary>
     public Container PendingFocusContainer;
-
-    /// <summary>
-    /// Whether the focused container of the WM is in sync with the OS. Mismatches between the
-    /// focus state of the WM and the OS occur when ignored windows (eg. via user's window rules)
-    /// or elevated windows are in focus.
-    /// </summary>
-    public bool IsFocusSynced
-    {
-      get
-      {
-        var foregroundHandle = GetForegroundWindow();
-        var focusedContainer = FocusedContainer;
-
-        if (focusedContainer is Window)
-          return (focusedContainer as Window).Hwnd == foregroundHandle;
-
-        return IntPtr.Zero == foregroundHandle;
-      }
-    }
 
     private readonly UserConfigService _userConfigService;
 

--- a/GlazeWM.Domain/DependencyInjection.cs
+++ b/GlazeWM.Domain/DependencyInjection.cs
@@ -58,6 +58,7 @@ namespace GlazeWM.Domain
       services.AddSingleton<ICommandHandler<AddWindowCommand>, AddWindowHandler>();
       services.AddSingleton<ICommandHandler<CloseWindowCommand>, CloseWindowHandler>();
       services.AddSingleton<ICommandHandler<FocusWindowCommand>, FocusWindowHandler>();
+      services.AddSingleton<ICommandHandler<IgnoreWindowCommand>, IgnoreWindowHandler>();
       services.AddSingleton<ICommandHandler<MoveWindowCommand>, MoveWindowHandler>();
       services.AddSingleton<ICommandHandler<RemoveWindowCommand>, RemoveWindowHandler>();
       services.AddSingleton<ICommandHandler<ResizeWindowCommand>, ResizeWindowHandler>();

--- a/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
+++ b/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
@@ -87,8 +87,9 @@ namespace GlazeWM.Domain.UserConfigs
           ExtractProcessName(string.Join(" ", commandParts[1..])),
           ExtractProcessArgs(string.Join(" ", commandParts[1..]))
         ),
-        // TODO: Temporary hack to avoid errors during `ValidateCommand`.
-        "ignore" => new NoopCommand(),
+        "ignore" => subjectContainer is Window
+          ? new IgnoreWindowCommand(subjectContainer as Window)
+          : new NoopCommand(),
         _ => throw new ArgumentException(null, nameof(commandString)),
       };
     }

--- a/GlazeWM.Domain/Windows/CommandHandlers/IgnoreWindowHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/IgnoreWindowHandler.cs
@@ -18,15 +18,15 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
 
     public CommandResponse Handle(IgnoreWindowCommand command)
     {
-      var window = command.WindowToIgnore;
+      var windowToIgnore = command.WindowToIgnore;
 
       // Store handle to ignored window.
-      _windowService.IgnoredHandles.Add(window.Hwnd);
+      _windowService.IgnoredHandles.Add(windowToIgnore.Hwnd);
 
-      if (window is IResizable)
-        _bus.Invoke(new DetachAndResizeContainerCommand(window));
+      if (windowToIgnore is IResizable)
+        _bus.Invoke(new DetachAndResizeContainerCommand(windowToIgnore));
       else
-        _bus.Invoke(new DetachContainerCommand(window));
+        _bus.Invoke(new DetachContainerCommand(windowToIgnore));
 
       _bus.Invoke(new RedrawContainersCommand());
 

--- a/GlazeWM.Domain/Windows/CommandHandlers/IgnoreWindowHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/IgnoreWindowHandler.cs
@@ -1,0 +1,36 @@
+﻿using GlazeWM.Domain.Containers;
+using GlazeWM.Domain.Containers.Commands;
+using GlazeWM.Domain.Windows.Commands;
+using GlazeWM.Infrastructure.Bussing;
+
+namespace GlazeWM.Domain.Windows.CommandHandlers
+{
+  internal class IgnoreWindowHandler : ICommandHandler<IgnoreWindowCommand>
+  {
+    private readonly Bus _bus;
+    private readonly WindowService _windowService;
+
+    public IgnoreWindowHandler(Bus bus, WindowService windowService)
+    {
+      _bus = bus;
+      _windowService = windowService;
+    }
+
+    public CommandResponse Handle(IgnoreWindowCommand command)
+    {
+      var window = command.WindowToIgnore;
+
+      // Store handle to ignored window.
+      _windowService.IgnoredHandles.Add(window.Hwnd);
+
+      if (window is IResizable)
+        _bus.Invoke(new DetachAndResizeContainerCommand(window));
+      else
+        _bus.Invoke(new DetachContainerCommand(window));
+
+      _bus.Invoke(new RedrawContainersCommand());
+
+      return CommandResponse.Ok;
+    }
+  }
+}

--- a/GlazeWM.Domain/Windows/Commands/IgnoreWindowCommand.cs
+++ b/GlazeWM.Domain/Windows/Commands/IgnoreWindowCommand.cs
@@ -1,0 +1,14 @@
+﻿using GlazeWM.Infrastructure.Bussing;
+
+namespace GlazeWM.Domain.Windows.Commands
+{
+  public class IgnoreWindowCommand : Command
+  {
+    public Window WindowToIgnore { get; }
+
+    public IgnoreWindowCommand(Window windowToClose)
+    {
+      WindowToIgnore = windowToClose;
+    }
+  }
+}

--- a/GlazeWM.Domain/Windows/Commands/IgnoreWindowCommand.cs
+++ b/GlazeWM.Domain/Windows/Commands/IgnoreWindowCommand.cs
@@ -6,9 +6,9 @@ namespace GlazeWM.Domain.Windows.Commands
   {
     public Window WindowToIgnore { get; }
 
-    public IgnoreWindowCommand(Window windowToClose)
+    public IgnoreWindowCommand(Window windowToIgnore)
     {
-      WindowToIgnore = windowToClose;
+      WindowToIgnore = windowToIgnore;
     }
   }
 }

--- a/GlazeWM.Domain/Windows/WindowService.cs
+++ b/GlazeWM.Domain/Windows/WindowService.cs
@@ -17,7 +17,12 @@ namespace GlazeWM.Domain.Windows
     /// Window handles to appbars (application desktop toolbars). Positioning changes of appbars
     /// can affect the working area of the parent monitor and requires windows to be redrawn.
     /// </summary>
-    public List<IntPtr> AppBarHandles { get; set; } = new List<IntPtr>();
+    public List<IntPtr> AppBarHandles { get; set; } = new();
+
+    /// <summary>
+    /// Window handles to ignored windows (ie. windows where 'ignore' command has been invoked).
+    /// </summary>
+    public List<IntPtr> IgnoredHandles { get; set; } = new();
 
     private readonly ContainerService _containerService;
     private readonly MonitorService _monitorService;


### PR DESCRIPTION
* Add "ignore" command for unmanaging a window and preventing keybindings from firing when the window has focus. Previously, there wasn't actually an actual "ignore" command - instead there was a specific check if "ignore" was present in window rules (and the window would not be managed if it was present).
* Change check when a keybinding is triggered to look up whether an ignored window currently has focus.
