### PR TITLE
refactor: change container methods for getting a container of a specific type

### DIFF
--- a/GlazeWM.Domain/Containers/CommandHandlers/AttachAndResizeContainerHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/AttachAndResizeContainerHandler.cs
@@ -25,7 +25,7 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
 
       _bus.Invoke(new AttachContainerCommand(childToAdd, targetParent, targetIndex));
 
-      var resizableSiblings = childToAdd.SiblingsOfType(typeof(IResizable));
+      var resizableSiblings = childToAdd.SiblingsOfType<IResizable>();
 
       var defaultPercent = 1.0 / (resizableSiblings.Count() + 1);
       (childToAdd as IResizable).SizePercentage = defaultPercent;

--- a/GlazeWM.Domain/Containers/CommandHandlers/FocusInDirectionHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/FocusInDirectionHandler.cs
@@ -46,8 +46,8 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
         return;
 
       var focusTarget = direction == Direction.RIGHT
-        ? focusedContainer.GetNextSiblingOfType<FloatingWindow>()
-        : focusedContainer.GetPreviousSiblingOfType<FloatingWindow>();
+        ? focusedContainer.NextSiblingOfType<FloatingWindow>()
+        : focusedContainer.PreviousSiblingOfType<FloatingWindow>();
 
       // Wrap if next/previous floating window is not found.
       if (focusTarget == null)
@@ -107,8 +107,8 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
         }
 
         var focusTarget = direction is Direction.UP or Direction.LEFT
-          ? focusReference.GetPreviousSiblingOfType<IResizable>()
-          : focusReference.GetNextSiblingOfType<IResizable>();
+          ? focusReference.PreviousSiblingOfType<IResizable>()
+          : focusReference.NextSiblingOfType<IResizable>();
 
         if (focusTarget == null)
         {

--- a/GlazeWM.Domain/Containers/CommandHandlers/FocusInDirectionHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/FocusInDirectionHandler.cs
@@ -46,14 +46,14 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
         return;
 
       var focusTarget = direction == Direction.RIGHT
-        ? focusedContainer.GetNextSiblingOfType(typeof(FloatingWindow))
-        : focusedContainer.GetPreviousSiblingOfType(typeof(FloatingWindow));
+        ? focusedContainer.GetNextSiblingOfType<FloatingWindow>()
+        : focusedContainer.GetPreviousSiblingOfType<FloatingWindow>();
 
       // Wrap if next/previous floating window is not found.
       if (focusTarget == null)
         focusTarget = direction == Direction.RIGHT
-          ? focusedContainer.SelfAndSiblingsOfType(typeof(FloatingWindow)).FirstOrDefault()
-          : focusedContainer.SelfAndSiblingsOfType(typeof(FloatingWindow)).LastOrDefault();
+          ? focusedContainer.SelfAndSiblingsOfType<FloatingWindow>().FirstOrDefault()
+          : focusedContainer.SelfAndSiblingsOfType<FloatingWindow>().LastOrDefault();
 
       if (focusTarget == null || focusTarget == focusedContainer)
         return;
@@ -107,8 +107,8 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
         }
 
         var focusTarget = direction is Direction.UP or Direction.LEFT
-          ? focusReference.GetPreviousSiblingOfType(typeof(IResizable))
-          : focusReference.GetNextSiblingOfType(typeof(IResizable));
+          ? focusReference.GetPreviousSiblingOfType<IResizable>()
+          : focusReference.GetNextSiblingOfType<IResizable>();
 
         if (focusTarget == null)
         {

--- a/GlazeWM.Domain/Containers/CommandHandlers/ToggleFocusModeHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/ToggleFocusModeHandler.cs
@@ -36,11 +36,11 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
 
       if (targetFocusMode == FocusMode.FLOATING)
         // Get the last focused tiling window within the workspace.
-        windowToFocus = focusedWorkspace.LastFocusedDescendantOfType(typeof(FloatingWindow))
+        windowToFocus = focusedWorkspace.LastFocusedDescendantOfType<FloatingWindow>()
           as Window;
       else
         // Get the last focused floating window within the workspace.
-        windowToFocus = focusedWorkspace.LastFocusedDescendantOfType(typeof(TilingWindow))
+        windowToFocus = focusedWorkspace.LastFocusedDescendantOfType<TilingWindow>()
           as Window;
 
       if (windowToFocus == null)

--- a/GlazeWM.Domain/Containers/Container.cs
+++ b/GlazeWM.Domain/Containers/Container.cs
@@ -136,53 +136,53 @@ namespace GlazeWM.Domain.Containers
       };
     }
 
-    public IEnumerable<Container> ChildrenOfType(Type type)
+    public IEnumerable<Container> ChildrenOfType<T>()
     {
-      return Children.Where(container => type.IsAssignableFrom(container.GetType()));
+      return Children.Where(container => typeof(T).IsAssignableFrom(container.GetType()));
     }
 
-    public IEnumerable<Container> SiblingsOfType(Type type)
+    public IEnumerable<Container> SiblingsOfType<T>()
     {
-      return Siblings.Where(container => type.IsAssignableFrom(container.GetType()));
+      return Siblings.Where(container => typeof(T).IsAssignableFrom(container.GetType()));
     }
 
-    public IEnumerable<Container> SelfAndSiblingsOfType(Type type)
+    public IEnumerable<Container> SelfAndSiblingsOfType<T>()
     {
-      return SelfAndSiblings.Where(container => type.IsAssignableFrom(container.GetType()));
+      return SelfAndSiblings.Where(container => typeof(T).IsAssignableFrom(container.GetType()));
     }
 
-    public Container GetNextSiblingOfType(Type type)
+    public Container GetNextSiblingOfType<T>()
     {
       return SelfAndSiblings
         .Skip(Index + 1)
-        .FirstOrDefault(container => type.IsAssignableFrom(container.GetType()));
+        .FirstOrDefault(container => typeof(T).IsAssignableFrom(container.GetType()));
     }
 
-    public Container GetPreviousSiblingOfType(Type type)
+    public Container GetPreviousSiblingOfType<T>()
     {
       return SelfAndSiblings
         .Take(Index)
         .Reverse()
-        .FirstOrDefault(container => type.IsAssignableFrom(container.GetType()));
+        .FirstOrDefault(container => typeof(T).IsAssignableFrom(container.GetType()));
     }
 
     /// <summary>
     /// Get the last focused child that matches the given type.
     /// </summary>
-    public Container LastFocusedChildOfType(Type type)
+    public Container LastFocusedChildOfType<T>()
     {
       return ChildFocusOrder.Find(
-        container => type.IsAssignableFrom(container.GetType())
+        container => typeof(T).IsAssignableFrom(container.GetType())
       );
     }
 
     /// <summary>
     /// Get the last focused descendant that matches the given type.
     /// </summary>
-    public Container LastFocusedDescendantOfType(Type type)
+    public Container LastFocusedDescendantOfType<T>()
     {
       return LastFocusedDescendantWithPredicate(
-        container => type.IsAssignableFrom(container.GetType())
+        container => typeof(T).IsAssignableFrom(container.GetType())
       );
     }
 

--- a/GlazeWM.Domain/Containers/Container.cs
+++ b/GlazeWM.Domain/Containers/Container.cs
@@ -151,14 +151,14 @@ namespace GlazeWM.Domain.Containers
       return SelfAndSiblings.Where(container => typeof(T).IsAssignableFrom(container.GetType()));
     }
 
-    public Container GetNextSiblingOfType<T>()
+    public Container NextSiblingOfType<T>()
     {
       return SelfAndSiblings
         .Skip(Index + 1)
         .FirstOrDefault(container => typeof(T).IsAssignableFrom(container.GetType()));
     }
 
-    public Container GetPreviousSiblingOfType<T>()
+    public Container PreviousSiblingOfType<T>()
     {
       return SelfAndSiblings
         .Take(Index)

--- a/GlazeWM.Domain/Containers/ContainerService.cs
+++ b/GlazeWM.Domain/Containers/ContainerService.cs
@@ -58,7 +58,7 @@ namespace GlazeWM.Domain.Containers
         return parent.Width;
 
       var innerGap = _userConfigService.UserConfig.Gaps.InnerGap;
-      var resizableSiblings = container.SelfAndSiblingsOfType(typeof(IResizable));
+      var resizableSiblings = container.SelfAndSiblingsOfType<IResizable>();
 
       return (int)((container as IResizable).SizePercentage
         * (parent.Width - (innerGap * (resizableSiblings.Count() - 1))));
@@ -76,7 +76,7 @@ namespace GlazeWM.Domain.Containers
         return parent.Height;
 
       var innerGap = _userConfigService.UserConfig.Gaps.InnerGap;
-      var resizableSiblings = container.SelfAndSiblingsOfType(typeof(IResizable));
+      var resizableSiblings = container.SelfAndSiblingsOfType<IResizable>();
 
       return (int)((container as IResizable).SizePercentage
         * (parent.Height - (innerGap * (resizableSiblings.Count() - 1))));
@@ -90,15 +90,15 @@ namespace GlazeWM.Domain.Containers
     {
       var parent = container.Parent as SplitContainer;
 
-      var isFirstOfType = container.SelfAndSiblingsOfType(typeof(IResizable)).First() == container;
+      var isFirstOfType = container.SelfAndSiblingsOfType<IResizable>().First() == container;
 
       if (parent.Layout == Layout.VERTICAL || isFirstOfType)
         return parent.X;
 
       var innerGap = _userConfigService.UserConfig.Gaps.InnerGap;
 
-      return container.GetPreviousSiblingOfType(typeof(IResizable)).X
-        + container.GetPreviousSiblingOfType(typeof(IResizable)).Width
+      return container.GetPreviousSiblingOfType<IResizable>().X
+        + container.GetPreviousSiblingOfType<IResizable>().Width
         + innerGap;
     }
 
@@ -110,15 +110,15 @@ namespace GlazeWM.Domain.Containers
     {
       var parent = container.Parent as SplitContainer;
 
-      var isFirstOfType = container.SelfAndSiblingsOfType(typeof(IResizable)).First() == container;
+      var isFirstOfType = container.SelfAndSiblingsOfType<IResizable>().First() == container;
 
       if (parent.Layout == Layout.HORIZONTAL || isFirstOfType)
         return parent.Y;
 
       var innerGap = _userConfigService.UserConfig.Gaps.InnerGap;
 
-      return container.GetPreviousSiblingOfType(typeof(IResizable)).Y
-        + container.GetPreviousSiblingOfType(typeof(IResizable)).Height
+      return container.GetPreviousSiblingOfType<IResizable>().Y
+        + container.GetPreviousSiblingOfType<IResizable>().Height
         + innerGap;
     }
 
@@ -129,8 +129,9 @@ namespace GlazeWM.Domain.Containers
     /// </summary>
     public Container GetDescendantInDirection(Container originContainer, Direction direction)
     {
-      var isDescendable = originContainer is SplitContainer
-        && originContainer.ChildrenOfType(typeof(IResizable)).Any();
+      var isDescendable =
+        originContainer is SplitContainer &&
+        originContainer.ChildrenOfType<IResizable>().Any();
 
       if (!isDescendable)
         return originContainer;
@@ -139,17 +140,17 @@ namespace GlazeWM.Domain.Containers
 
       if (layout != direction.GetCorrespondingLayout())
         return GetDescendantInDirection(
-          originContainer.LastFocusedChildOfType(typeof(IResizable)),
+          originContainer.LastFocusedChildOfType<IResizable>(),
           direction
         );
       else if (direction is Direction.UP or Direction.LEFT)
         return GetDescendantInDirection(
-          originContainer.ChildrenOfType(typeof(IResizable)).First(),
+          originContainer.ChildrenOfType<IResizable>().First(),
           direction
         );
       else
         return GetDescendantInDirection(
-          originContainer.ChildrenOfType(typeof(IResizable)).Last(),
+          originContainer.ChildrenOfType<IResizable>().Last(),
           direction
         );
     }

--- a/GlazeWM.Domain/Containers/ContainerService.cs
+++ b/GlazeWM.Domain/Containers/ContainerService.cs
@@ -97,8 +97,8 @@ namespace GlazeWM.Domain.Containers
 
       var innerGap = _userConfigService.UserConfig.Gaps.InnerGap;
 
-      return container.GetPreviousSiblingOfType<IResizable>().X
-        + container.GetPreviousSiblingOfType<IResizable>().Width
+      return container.PreviousSiblingOfType<IResizable>().X
+        + container.PreviousSiblingOfType<IResizable>().Width
         + innerGap;
     }
 
@@ -117,8 +117,8 @@ namespace GlazeWM.Domain.Containers
 
       var innerGap = _userConfigService.UserConfig.Gaps.InnerGap;
 
-      return container.GetPreviousSiblingOfType<IResizable>().Y
-        + container.GetPreviousSiblingOfType<IResizable>().Height
+      return container.PreviousSiblingOfType<IResizable>().Y
+        + container.PreviousSiblingOfType<IResizable>().Height
         + innerGap;
     }
 

--- a/GlazeWM.Domain/Windows/CommandHandlers/MoveWindowHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/MoveWindowHandler.cs
@@ -84,8 +84,8 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
     private void SwapSiblingContainers(Window windowToMove, Direction direction)
     {
       var siblingInDirection = direction is Direction.UP or Direction.LEFT
-        ? windowToMove.GetPreviousSiblingOfType<IResizable>()
-        : windowToMove.GetNextSiblingOfType<IResizable>();
+        ? windowToMove.PreviousSiblingOfType<IResizable>()
+        : windowToMove.NextSiblingOfType<IResizable>();
 
       // Swap the window with sibling in given direction.
       if (siblingInDirection is Window)
@@ -181,8 +181,8 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
         .FirstOrDefault(container => container.Parent == ancestorWithLayout);
 
       var insertionReferenceSibling = direction is Direction.UP or Direction.LEFT
-        ? insertionReference.GetPreviousSiblingOfType<IResizable>()
-        : insertionReference.GetNextSiblingOfType<IResizable>();
+        ? insertionReference.PreviousSiblingOfType<IResizable>()
+        : insertionReference.NextSiblingOfType<IResizable>();
 
       if (insertionReferenceSibling is SplitContainer)
       {

--- a/GlazeWM.Domain/Windows/CommandHandlers/MoveWindowHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/MoveWindowHandler.cs
@@ -76,16 +76,16 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
     private static bool HasSiblingInDirection(Window windowToMove, Direction direction)
     {
       if (direction is Direction.UP or Direction.LEFT)
-        return windowToMove != windowToMove.SelfAndSiblingsOfType(typeof(IResizable)).First();
+        return windowToMove != windowToMove.SelfAndSiblingsOfType<IResizable>().First();
 
-      return windowToMove != windowToMove.SelfAndSiblingsOfType(typeof(IResizable)).Last();
+      return windowToMove != windowToMove.SelfAndSiblingsOfType<IResizable>().Last();
     }
 
     private void SwapSiblingContainers(Window windowToMove, Direction direction)
     {
       var siblingInDirection = direction is Direction.UP or Direction.LEFT
-        ? windowToMove.GetPreviousSiblingOfType(typeof(IResizable))
-        : windowToMove.GetNextSiblingOfType(typeof(IResizable));
+        ? windowToMove.GetPreviousSiblingOfType<IResizable>()
+        : windowToMove.GetNextSiblingOfType<IResizable>();
 
       // Swap the window with sibling in given direction.
       if (siblingInDirection is Window)
@@ -181,8 +181,8 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
         .FirstOrDefault(container => container.Parent == ancestorWithLayout);
 
       var insertionReferenceSibling = direction is Direction.UP or Direction.LEFT
-        ? insertionReference.GetPreviousSiblingOfType(typeof(IResizable))
-        : insertionReference.GetNextSiblingOfType(typeof(IResizable));
+        ? insertionReference.GetPreviousSiblingOfType<IResizable>()
+        : insertionReference.GetNextSiblingOfType<IResizable>();
 
       if (insertionReferenceSibling is SplitContainer)
       {

--- a/GlazeWM.Domain/Windows/CommandHandlers/ResizeWindowHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/ResizeWindowHandler.cs
@@ -37,7 +37,7 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
 
       // Get container and its siblings to resize.
       var containerToResize = GetContainerToResize(windowToResize, dimensionToResize);
-      var resizableSiblings = containerToResize.SiblingsOfType(typeof(IResizable));
+      var resizableSiblings = containerToResize.SiblingsOfType<IResizable>();
 
       // Ignore cases where the container to resize is a workspace or the only child.
       if (!resizableSiblings.Any() || containerToResize is Workspace)
@@ -116,7 +116,7 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
         (layout == Layout.HORIZONTAL && dimensionToResize == ResizeDimension.HEIGHT) ||
         (layout == Layout.VERTICAL && dimensionToResize == ResizeDimension.WIDTH);
 
-      var hasResizableSiblings = windowToResize.SiblingsOfType(typeof(IResizable)).Any();
+      var hasResizableSiblings = windowToResize.SiblingsOfType<IResizable>().Any();
 
       if (!isInverseResize && !hasResizableSiblings && grandparent is IResizable)
         return grandparent;
@@ -155,7 +155,7 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
       ResizeDimension dimensionToResize)
     {
       // Get available width/height that can be resized (ie. exclude inner gaps).
-      var resizableLength = containerToResize.SelfAndSiblingsOfType(typeof(IResizable)).Aggregate(
+      var resizableLength = containerToResize.SelfAndSiblingsOfType<IResizable>().Aggregate(
         1.0,
         (sum, container) =>
           dimensionToResize == ResizeDimension.WIDTH

--- a/GlazeWM.Domain/Windows/CommandHandlers/ToggleFloatingHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/ToggleFloatingHandler.cs
@@ -32,7 +32,7 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
       // Keep reference to the window's ancestor workspace prior to detaching.
       var workspace = WorkspaceService.GetWorkspaceFromChildContainer(floatingWindow);
 
-      var insertionTarget = workspace.LastFocusedDescendantOfType(typeof(IResizable));
+      var insertionTarget = workspace.LastFocusedDescendantOfType<IResizable>();
 
       var tilingWindow = new TilingWindow(
         floatingWindow.Handle,

--- a/GlazeWM.Domain/Windows/EventHandlers/WindowMinimizeEndedHandler.cs
+++ b/GlazeWM.Domain/Windows/EventHandlers/WindowMinimizeEndedHandler.cs
@@ -47,7 +47,7 @@ namespace GlazeWM.Domain.Windows.EventHandlers
         return;
 
       var workspace = WorkspaceService.GetWorkspaceFromChildContainer(window);
-      var insertionTarget = workspace.LastFocusedDescendantOfType(typeof(IResizable));
+      var insertionTarget = workspace.LastFocusedDescendantOfType<IResizable>();
 
       // Insert the created tiling window after the last focused descendant of the workspace.
       if (insertionTarget == null)

--- a/GlazeWM.Domain/Windows/EventHandlers/WindowMovedOrResizedHandler.cs
+++ b/GlazeWM.Domain/Windows/EventHandlers/WindowMovedOrResizedHandler.cs
@@ -60,7 +60,7 @@ namespace GlazeWM.Domain.Windows.EventHandlers
     {
       // Snap window to its original position even if it's not being resized.
       var hasNoResizableSiblings = window.Parent is Workspace
-        && !window.SiblingsOfType(typeof(IResizable)).Any();
+        && !window.SiblingsOfType<IResizable>().Any();
 
       if (hasNoResizableSiblings)
       {

--- a/GlazeWM.Domain/Workspaces/CommandHandlers/MoveWindowToWorkspaceHandler.cs
+++ b/GlazeWM.Domain/Workspaces/CommandHandlers/MoveWindowToWorkspaceHandler.cs
@@ -84,7 +84,7 @@ namespace GlazeWM.Domain.Workspaces.CommandHandlers
 
     private void MoveTilingWindowToWorkspace(TilingWindow windowToMove, Workspace targetWorkspace)
     {
-      var insertionTarget = targetWorkspace.LastFocusedDescendantOfType(typeof(IResizable));
+      var insertionTarget = targetWorkspace.LastFocusedDescendantOfType<IResizable>();
 
       // Insert the window into the target workspace.
       if (insertionTarget == null)


### PR DESCRIPTION
* Change Container methods that get a container of specific type. Change from format: `container.ChildrenOfType(typeof(IResizable))` -> `container.ChildrenOfType<IResizable>()`.
* rename `GetNextSiblingOfType` and `GetPreviousSiblingOfType` to exclude `Get`.