### PR TITLE
fix: out of order commands & events

### DIFF
--- a/GlazeWM.Infrastructure/Bussing/Bus.cs
+++ b/GlazeWM.Infrastructure/Bussing/Bus.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Reactive.Subjects;
+using System.Threading.Tasks;
 
 namespace GlazeWM.Infrastructure.Bussing
 {
@@ -37,6 +38,11 @@ namespace GlazeWM.Infrastructure.Bussing
       }
     }
 
+    public Task<CommandResponse> InvokeAsync<T>(T command) where T : Command
+    {
+      return Task.Run(() => Invoke(command));
+    }
+
     /// <summary>
     /// Sends event to appropriate event handlers.
     /// </summary>
@@ -58,6 +64,11 @@ namespace GlazeWM.Infrastructure.Bussing
 
       // Emit event through subject.
       Events.OnNext(@event);
+    }
+
+    public Task EmitAsync<T>(T @event) where T : Event
+    {
+      return Task.Run(() => RaiseEvent(@event));
     }
   }
 }

--- a/GlazeWM.Infrastructure/WindowsApi/SystemEventService.cs
+++ b/GlazeWM.Infrastructure/WindowsApi/SystemEventService.cs
@@ -25,7 +25,7 @@ namespace GlazeWM.Infrastructure.WindowsApi
         handler => SystemEvents.DisplaySettingsChanged -= handler
       );
 
-      displaySettingChanges.Subscribe((_) => _bus.RaiseEvent(new DisplaySettingsChangedEvent()));
+      displaySettingChanges.Subscribe((_) => _bus.EmitAsync(new DisplaySettingsChangedEvent()));
     }
   }
 }

--- a/GlazeWM.Infrastructure/WindowsApi/WindowEventService.cs
+++ b/GlazeWM.Infrastructure/WindowsApi/WindowEventService.cs
@@ -61,7 +61,7 @@ namespace GlazeWM.Infrastructure.WindowsApi
       };
 
       if (eventToRaise is not null)
-        _bus.RaiseEvent((dynamic)eventToRaise);
+        _bus.EmitAsync((dynamic)eventToRaise);
     }
   }
 }


### PR DESCRIPTION
Keybinding hooks, window event hooks, and system event hooks all run on the main thread after the changes in #130. To ensure that state changes are synchronous, there's a lock statement in the `Bus.Invoke` and `Bus.RaiseEvent` methods. However, since these hooks are all now on the same thread, the lock statement no longer takes effect and events/commands would be invoked while another event/command is being processed. This caused issues with the `move to workspace <NAME>` command (ref #137).

* To get the lock statement working again in `Bus`, add new `Bus` methods for invoking commands & raising events on a new thread. 