### PR TITLE
refactor: remove `PendingFocusContainer`; simplify how focus is set after window close

### DIFF
--- a/GlazeWM.Domain/Containers/ContainerService.cs
+++ b/GlazeWM.Domain/Containers/ContainerService.cs
@@ -33,12 +33,6 @@ namespace GlazeWM.Domain.Containers
     public FocusMode FocusMode => FocusedContainer is FloatingWindow ?
       FocusMode.FLOATING : FocusMode.TILING;
 
-    /// <summary>
-    /// If set, this container overrides the target container to set focus to on the next
-    /// focus window event (ie. `EVENT_SYSTEM_FOREGROUND`).
-    /// </summary>
-    public Container PendingFocusContainer;
-
     private readonly UserConfigService _userConfigService;
 
     public ContainerService(UserConfigService userConfigService)

--- a/GlazeWM.Domain/Windows/CommandHandlers/UnmanageWindowHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/UnmanageWindowHandler.cs
@@ -8,12 +8,10 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
   internal class UnmanageWindowHandler : ICommandHandler<UnmanageWindowCommand>
   {
     private readonly Bus _bus;
-    private readonly ContainerService _containerService;
 
-    public UnmanageWindowHandler(Bus bus, ContainerService containerService)
+    public UnmanageWindowHandler(Bus bus)
     {
       _bus = bus;
-      _containerService = containerService;
     }
 
     public CommandResponse Handle(UnmanageWindowCommand command)
@@ -32,8 +30,9 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
       // Get container to switch focus to after the window has been removed. The OS automatically
       // switches focus to a different window after closing, so by setting `PendingFocusContainer`
       // this behavior is overridden.
-      _containerService.PendingFocusContainer = parent.LastFocusedDescendant
-        ?? grandparent.LastFocusedDescendant;
+      // TODO: Container to focus should depend on focus mode.
+      var containerToFocus = parent.LastFocusedDescendant ?? grandparent.LastFocusedDescendant;
+      _bus.InvokeAsync(new SetNativeFocusCommand(containerToFocus));
 
       return CommandResponse.Ok;
     }

--- a/GlazeWM.Domain/Windows/CommandHandlers/UnmanageWindowHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/UnmanageWindowHandler.cs
@@ -27,10 +27,12 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
       else
         _bus.Invoke(new DetachContainerCommand(window));
 
-      // Get container to switch focus to after the window has been removed. The OS automatically
-      // switches focus to a different window after closing, so by setting `PendingFocusContainer`
-      // this behavior is overridden.
+      // The OS automatically switches focus to a different window after closing. Use `InvokeAsync`
+      // to ensure focus gets set to `containerToFocus` *after* the OS sets focus. This will cause
+      // focus to briefly flicker to the OS focus target and then to the WM's focus target.
       // TODO: Container to focus should depend on focus mode.
+      // TODO: Consider moving this out to `WindowHiddenHandler` and `WindowClosedHandler` after
+      // redraw. More likely that it runs after OS focus event.
       var containerToFocus = parent.LastFocusedDescendant ?? grandparent.LastFocusedDescendant;
       _bus.InvokeAsync(new SetNativeFocusCommand(containerToFocus));
 

--- a/GlazeWM.Domain/Windows/EventHandlers/WindowFocusedHandler.cs
+++ b/GlazeWM.Domain/Windows/EventHandlers/WindowFocusedHandler.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using GlazeWM.Domain.Common.Utils;
-using GlazeWM.Domain.Containers;
 using GlazeWM.Domain.Containers.Commands;
 using GlazeWM.Domain.Containers.Events;
 using GlazeWM.Infrastructure.Bussing;
@@ -13,33 +12,20 @@ namespace GlazeWM.Domain.Windows.EventHandlers
   {
     private readonly Bus _bus;
     private readonly WindowService _windowService;
-    private readonly ContainerService _containerService;
     private readonly ILogger<WindowFocusedHandler> _logger;
 
     public WindowFocusedHandler(
       Bus bus,
       WindowService windowService,
-      ContainerService containerService,
       ILogger<WindowFocusedHandler> logger)
     {
       _bus = bus;
       _windowService = windowService;
-      _containerService = containerService;
       _logger = logger;
     }
 
     public void Handle(WindowFocusedEvent @event)
     {
-      var pendingFocusContainer = _containerService.PendingFocusContainer;
-
-      // Override the container to set focus to (ie. when changing focus after a window is closed).
-      if (pendingFocusContainer != null)
-      {
-        _bus.Invoke(new SetNativeFocusCommand(pendingFocusContainer));
-        _containerService.PendingFocusContainer = null;
-        return;
-      }
-
       var window = _windowService.GetWindows()
         .FirstOrDefault(window => window.Handle == @event.WindowHandle);
 

--- a/GlazeWM.Domain/Windows/EventHandlers/WindowMinimizedHandler.cs
+++ b/GlazeWM.Domain/Windows/EventHandlers/WindowMinimizedHandler.cs
@@ -54,8 +54,9 @@ namespace GlazeWM.Domain.Windows.EventHandlers
 
       _bus.Invoke(new ReplaceContainerCommand(minimizedWindow, window.Parent, window.Index));
 
+      // TODO: Container to focus should depend on focus mode.
       var focusTarget = workspace.LastFocusedDescendantExcluding(minimizedWindow) ?? workspace;
-      _bus.Invoke(new SetNativeFocusCommand(focusTarget));
+      _bus.InvokeAsync(new SetNativeFocusCommand(focusTarget));
 
       _containerService.ContainersToRedraw.Add(workspace);
       _bus.Invoke(new RedrawContainersCommand());

--- a/GlazeWM.Domain/Workspaces/CommandHandlers/FocusWorkspaceHandler.cs
+++ b/GlazeWM.Domain/Workspaces/CommandHandlers/FocusWorkspaceHandler.cs
@@ -64,14 +64,12 @@ namespace GlazeWM.Domain.Workspaces.CommandHandlers
 
       // Get empty workspace to destroy (if any are found). Cannot destroy empty workspaces if
       // they're the only workspace on the monitor or are pending focus.
-      var workspaceToDestroy = _workspaceService.GetActiveWorkspaces()
-        .FirstOrDefault(workspace =>
-        {
-          return !workspace.KeepAlive
-            && !workspace.HasChildren()
-            && !workspace.IsDisplayed
-            && _containerService.PendingFocusContainer != workspace;
-        });
+      var workspaceToDestroy = _workspaceService
+        .GetActiveWorkspaces()
+        .FirstOrDefault(
+          (workspace) =>
+            !workspace.KeepAlive && !workspace.HasChildren() && !workspace.IsDisplayed
+        );
 
       if (workspaceToDestroy != null)
         _bus.Invoke(new DeactivateWorkspaceCommand(workspaceToDestroy));


### PR DESCRIPTION
* Remove `ContainerService.PendingFocusContainer`. Reassign focus after window close by calling `SetNativeFocusCommand` asynchronously. This ensure that focus gets corrected *after* the OS initially sets focus.