### PR TITLE
fix: focus reassignment after window removal

### DIFF
--- a/GlazeWM.Domain/Containers/Container.cs
+++ b/GlazeWM.Domain/Containers/Container.cs
@@ -110,6 +110,32 @@ namespace GlazeWM.Domain.Containers
       }
     }
 
+    /// <summary>
+    /// Leaf nodes (ie. windows and workspaces) in order of last focus.
+    /// </summary>
+    public IEnumerable<Container> DescendantFocusOrder
+    {
+      get
+      {
+        var stack = new Stack<Container>();
+        stack.Push(this);
+
+        // Do a depth-first search using child focus order.
+        while (stack.Count > 0)
+        {
+          var current = stack.Pop();
+
+          // Get containers that have no children. Descendant also cannot be the container itself.
+          if (current != this && !current.HasChildren())
+            yield return current;
+
+          // Reverse the child focus order so that the first element is pushed last/popped first.
+          foreach (var focusChild in current.ChildFocusOrder.AsEnumerable().Reverse())
+            stack.Push(focusChild);
+        }
+      }
+    }
+
     public bool IsDetached()
     {
       return Parent is null;
@@ -181,7 +207,7 @@ namespace GlazeWM.Domain.Containers
     /// </summary>
     public Container LastFocusedDescendantOfType<T>()
     {
-      return LastFocusedDescendantWithPredicate(
+      return DescendantFocusOrder.FirstOrDefault(
         container => typeof(T).IsAssignableFrom(container.GetType())
       );
     }
@@ -191,37 +217,9 @@ namespace GlazeWM.Domain.Containers
     /// </summary>
     public Container LastFocusedDescendantExcluding(Container containerToExclude)
     {
-      return LastFocusedDescendantWithPredicate(
+      return DescendantFocusOrder.FirstOrDefault(
         container => container != containerToExclude
       );
-    }
-
-    /// <summary>
-    /// Get the last focused descendant that matches a given predicate.
-    /// </summary>
-    private Container LastFocusedDescendantWithPredicate(Predicate<Container> predicate)
-    {
-      var stack = new Stack<Container>();
-      stack.Push(this);
-
-      // Do a depth-first search using child focus order.
-      while (stack.Count > 0)
-      {
-        var current = stack.Pop();
-
-        // The focused descendant cannot be the container itself or any containers that have
-        // children.
-        var isMatch = current != this && !current.HasChildren() && predicate(current);
-
-        if (isMatch)
-          return current;
-
-        // Reverse the child focus order so that the first element is pushed last/popped first.
-        foreach (var focusChild in current.ChildFocusOrder.AsEnumerable().Reverse())
-          stack.Push(focusChild);
-      }
-
-      return null;
     }
   }
 }

--- a/GlazeWM.Domain/Containers/Container.cs
+++ b/GlazeWM.Domain/Containers/Container.cs
@@ -211,15 +211,5 @@ namespace GlazeWM.Domain.Containers
         container => typeof(T).IsAssignableFrom(container.GetType())
       );
     }
-
-    /// <summary>
-    /// Get the last focused descendant that is not the given container.
-    /// </summary>
-    public Container LastFocusedDescendantExcluding(Container containerToExclude)
-    {
-      return DescendantFocusOrder.FirstOrDefault(
-        container => container != containerToExclude
-      );
-    }
   }
 }

--- a/GlazeWM.Domain/Windows/EventHandlers/WindowMinimizedHandler.cs
+++ b/GlazeWM.Domain/Windows/EventHandlers/WindowMinimizedHandler.cs
@@ -52,10 +52,12 @@ namespace GlazeWM.Domain.Windows.EventHandlers
         previousState
       );
 
+      // Get container to switch focus to after the window has been minimized.
+      var focusTarget = WindowService.GetFocusTargetAfterRemoval(window);
+
       _bus.Invoke(new ReplaceContainerCommand(minimizedWindow, window.Parent, window.Index));
 
-      // TODO: Container to focus should depend on focus mode.
-      var focusTarget = workspace.LastFocusedDescendantExcluding(minimizedWindow) ?? workspace;
+      // Reassign focus to appropriate container.
       _bus.InvokeAsync(new SetNativeFocusCommand(focusTarget));
 
       _containerService.ContainersToRedraw.Add(workspace);

--- a/GlazeWM.Domain/Windows/WindowService.cs
+++ b/GlazeWM.Domain/Windows/WindowService.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using GlazeWM.Domain.Containers;
 using GlazeWM.Domain.Monitors;
+using GlazeWM.Domain.Workspaces;
 using GlazeWM.Infrastructure.WindowsApi;
 using static GlazeWM.Infrastructure.WindowsApi.WindowsApiService;
 
@@ -216,6 +217,24 @@ namespace GlazeWM.Domain.Windows
         FullscreenWindow => WindowType.FULLSCREEN,
         _ => throw new ArgumentException(null, nameof(window)),
       };
+    }
+
+    /// <summary>
+    /// Get container to focus after the given window is unmanaged or moved to another workspace.
+    /// </summary>
+    public static Container GetFocusTargetAfterRemoval(Window removedWindow)
+    {
+      var parentWorkspace = removedWindow.Ancestors.OfType<Workspace>().First();
+      var windowType = WindowService.GetWindowType(removedWindow);
+
+      var focusTargetOfType = parentWorkspace.DescendantFocusOrder.FirstOrDefault(
+        (descendant) =>
+          removedWindow is FloatingWindow
+            ? (descendant is FloatingWindow)
+            : (descendant is TilingWindow)
+      );
+
+      return focusTargetOfType ?? parentWorkspace.LastFocusedDescendant ?? parentWorkspace;
     }
   }
 }

--- a/GlazeWM.Domain/Windows/WindowService.cs
+++ b/GlazeWM.Domain/Windows/WindowService.cs
@@ -220,18 +220,23 @@ namespace GlazeWM.Domain.Windows
     }
 
     /// <summary>
-    /// Get container to focus after the given window is unmanaged or moved to another workspace.
+    /// Get container to focus after the given window is unmanaged, minimized, or moved to another
+    /// workspace.
     /// </summary>
     public static Container GetFocusTargetAfterRemoval(Window removedWindow)
     {
-      var parentWorkspace = removedWindow.Ancestors.OfType<Workspace>().First();
-      var windowType = WindowService.GetWindowType(removedWindow);
+      var parentWorkspace = WorkspaceService.GetWorkspaceFromChildContainer(removedWindow);
 
       var focusTargetOfType = parentWorkspace.DescendantFocusOrder.FirstOrDefault(
         (descendant) =>
-          removedWindow is FloatingWindow
-            ? (descendant is FloatingWindow)
-            : (descendant is TilingWindow)
+        {
+          if (descendant == removedWindow)
+            return false;
+
+          return removedWindow is FloatingWindow
+            ? descendant is FloatingWindow
+            : descendant is TilingWindow;
+        }
       );
 
       return focusTargetOfType ?? parentWorkspace.LastFocusedDescendant ?? parentWorkspace;

--- a/GlazeWM.Domain/Workspaces/CommandHandlers/FocusWorkspaceHandler.cs
+++ b/GlazeWM.Domain/Workspaces/CommandHandlers/FocusWorkspaceHandler.cs
@@ -39,8 +39,7 @@ namespace GlazeWM.Domain.Workspaces.CommandHandlers
       var workspaceToFocus = _workspaceService.GetActiveWorkspaceByName(workspaceName)
         ?? ActivateWorkspace(workspaceName);
 
-      // Get the currently focused workspace. This can be null if there currently
-      // isn't a container that has focus.
+      // Get the currently focused workspace.
       var focusedWorkspace = _workspaceService.GetFocusedWorkspace();
 
       if (focusedWorkspace == workspaceToFocus)


### PR DESCRIPTION
* Add a consistent way of getting the window to reassign focus to after a window is unmanaged, minimized, or moved to another workspace.