### PR TITLE
fix: invalid reference when running multiple commands

### DIFF
--- a/GlazeWM.Domain/Containers/Container.cs
+++ b/GlazeWM.Domain/Containers/Container.cs
@@ -7,6 +7,11 @@ namespace GlazeWM.Domain.Containers
 {
   public abstract class Container
   {
+    /// <summary>
+    /// A unique identifier for the particular container. Implementation varies between container
+    /// types (eg. windows use their handle, whereas monitors use device name).
+    /// </summary>
+    public abstract string Id { get; init; }
     public virtual int Height { get; set; }
     public virtual int Width { get; set; }
     public virtual int X { get; set; }

--- a/GlazeWM.Domain/Containers/ContainerService.cs
+++ b/GlazeWM.Domain/Containers/ContainerService.cs
@@ -40,6 +40,11 @@ namespace GlazeWM.Domain.Containers
       _userConfigService = userConfigService;
     }
 
+    public Container GetContainerById(string id)
+    {
+      return ContainerTree.SelfAndDescendants.FirstOrDefault(container => container.Id == id);
+    }
+
     /// <summary>
     /// Calculates the width of a container that can be resized programatically. This
     /// calculation is shared by windows and split containers.

--- a/GlazeWM.Domain/Containers/RootContainer.cs
+++ b/GlazeWM.Domain/Containers/RootContainer.cs
@@ -4,6 +4,6 @@ namespace GlazeWM.Domain.Containers
 {
   public sealed class RootContainer : Container
   {
-    public override string Id { get; init; } = new Guid().ToString();
+    public override string Id { get; init; } = $"ROOT/{new Guid().ToString()}";
   }
 }

--- a/GlazeWM.Domain/Containers/RootContainer.cs
+++ b/GlazeWM.Domain/Containers/RootContainer.cs
@@ -1,6 +1,9 @@
-﻿namespace GlazeWM.Domain.Containers
+﻿using System;
+
+namespace GlazeWM.Domain.Containers
 {
   public sealed class RootContainer : Container
   {
+    public override string Id { get; init; } = new Guid().ToString();
   }
 }

--- a/GlazeWM.Domain/Containers/SplitContainer.cs
+++ b/GlazeWM.Domain/Containers/SplitContainer.cs
@@ -6,7 +6,7 @@ namespace GlazeWM.Domain.Containers
 {
   public class SplitContainer : Container, IResizable
   {
-    public override string Id { get; init; } = new Guid().ToString();
+    public override string Id { get; init; } = $"SPLIT/{new Guid().ToString()}";
     public Layout Layout { get; set; } = Layout.HORIZONTAL;
 
     public double SizePercentage { get; set; } = 1;

--- a/GlazeWM.Domain/Containers/SplitContainer.cs
+++ b/GlazeWM.Domain/Containers/SplitContainer.cs
@@ -1,10 +1,12 @@
-﻿using GlazeWM.Domain.Common.Enums;
+﻿using System;
+using GlazeWM.Domain.Common.Enums;
 using GlazeWM.Infrastructure;
 
 namespace GlazeWM.Domain.Containers
 {
   public class SplitContainer : Container, IResizable
   {
+    public override string Id { get; init; } = new Guid().ToString();
     public Layout Layout { get; set; } = Layout.HORIZONTAL;
 
     public double SizePercentage { get; set; } = 1;

--- a/GlazeWM.Domain/Monitors/Monitor.cs
+++ b/GlazeWM.Domain/Monitors/Monitor.cs
@@ -23,7 +23,7 @@ namespace GlazeWM.Domain.Monitors
       int x,
       int y)
     {
-      Id = deviceName;
+      Id = $"MONITOR/{deviceName}";
       DeviceName = deviceName;
       Width = width;
       Height = height;

--- a/GlazeWM.Domain/Monitors/Monitor.cs
+++ b/GlazeWM.Domain/Monitors/Monitor.cs
@@ -5,6 +5,7 @@ namespace GlazeWM.Domain.Monitors
 {
   public sealed class Monitor : Container
   {
+    public override string Id { get; init; }
     public string DeviceName { get; set; }
     public override int Width { get; set; }
     public override int Height { get; set; }
@@ -22,6 +23,7 @@ namespace GlazeWM.Domain.Monitors
       int x,
       int y)
     {
+      Id = deviceName;
       DeviceName = deviceName;
       Width = width;
       Height = height;

--- a/GlazeWM.Domain/UserConfigs/CommandHandlers/RegisterKeybindingsHandler.cs
+++ b/GlazeWM.Domain/UserConfigs/CommandHandlers/RegisterKeybindingsHandler.cs
@@ -53,22 +53,27 @@ namespace GlazeWM.Domain.UserConfigs.CommandHandlers
                 return;
 
               var subjectContainer = _containerService.FocusedContainer;
+              var subjectContainerId = subjectContainer.Id;
 
               // Invoke commands in sequence on keybinding press.
               foreach (var commandString in formattedCommandStrings)
               {
-                var parsedCommand = _commandParsingService.ParseCommand(
-                  commandString,
-                  subjectContainer
-                );
-
                 // Avoid calling command if container gets detached. This is to prevent crashes
                 // for edge cases like ["close", "move to workspace X"].
                 if (subjectContainer.IsDetached())
                   return;
 
+                var parsedCommand = _commandParsingService.ParseCommand(
+                  commandString,
+                  subjectContainer
+                );
+
                 // Use `dynamic` to resolve the command type at runtime and allow multiple dispatch.
                 _bus.Invoke((dynamic)parsedCommand);
+
+                // Update subject container in case the reference changes (eg. when going from a tiling to a
+                // floating window).
+                subjectContainer = _containerService.GetContainerById(subjectContainerId);
               }
             });
           });

--- a/GlazeWM.Domain/Windows/CommandHandlers/RunWindowRulesHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/RunWindowRulesHandler.cs
@@ -31,9 +31,14 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
         .SelectMany(rule => rule.CommandList)
         .Select(commandString => CommandParsingService.FormatCommand(commandString));
 
+      // Window to use as subject container when invoking commands.
       var subjectWindow = window;
+
       foreach (var commandString in commandStrings)
       {
+        if (subjectWindow.IsDetached())
+          return CommandResponse.Ok;
+
         var parsedCommand = _commandParsingService.ParseCommand(commandString, subjectWindow);
 
         // Invoke commands in the matching window rules. Use `dynamic` to resolve the command type

--- a/GlazeWM.Domain/Windows/Window.cs
+++ b/GlazeWM.Domain/Windows/Window.cs
@@ -31,7 +31,7 @@ namespace GlazeWM.Domain.Windows
 
     protected Window(IntPtr handle, Rect floatingPlacement, RectDelta borderDelta)
     {
-      Id = handle.ToString("x");
+      Id = $"WINDOW/{handle.ToString("x")}";
       Handle = handle;
       FloatingPlacement = floatingPlacement;
       BorderDelta = borderDelta;

--- a/GlazeWM.Domain/Windows/Window.cs
+++ b/GlazeWM.Domain/Windows/Window.cs
@@ -8,6 +8,7 @@ namespace GlazeWM.Domain.Windows
 {
   public abstract class Window : Container
   {
+    public override string Id { get; init; }
     public IntPtr Handle { get; }
 
     /// <summary>
@@ -30,6 +31,7 @@ namespace GlazeWM.Domain.Windows
 
     protected Window(IntPtr handle, Rect floatingPlacement, RectDelta borderDelta)
     {
+      Id = handle.ToString("x");
       Handle = handle;
       FloatingPlacement = floatingPlacement;
       BorderDelta = borderDelta;

--- a/GlazeWM.Domain/Windows/WindowService.cs
+++ b/GlazeWM.Domain/Windows/WindowService.cs
@@ -42,6 +42,11 @@ namespace GlazeWM.Domain.Windows
       return _containerService.ContainerTree.Descendants.OfType<Window>();
     }
 
+    public Window GetWindowByHandle(IntPtr handle)
+    {
+      return GetWindows().FirstOrDefault(window => window.Handle == handle);
+    }
+
     /// <summary>
     /// Get the id of the process that created the window.
     /// </summary>

--- a/GlazeWM.Domain/Workspaces/Workspace.cs
+++ b/GlazeWM.Domain/Workspaces/Workspace.cs
@@ -63,7 +63,7 @@ namespace GlazeWM.Domain.Workspaces
 
     public Workspace(string name)
     {
-      Id = name;
+      Id = $"WORKSPACE/{name}";
       Name = name;
     }
   }

--- a/GlazeWM.Domain/Workspaces/Workspace.cs
+++ b/GlazeWM.Domain/Workspaces/Workspace.cs
@@ -8,6 +8,7 @@ namespace GlazeWM.Domain.Workspaces
 {
   public sealed class Workspace : SplitContainer
   {
+    public override string Id { get; init; }
     public string Name { get; set; }
 
     private readonly UserConfigService _userConfigService =
@@ -62,6 +63,7 @@ namespace GlazeWM.Domain.Workspaces
 
     public Workspace(string name)
     {
+      Id = name;
       Name = name;
     }
   }


### PR DESCRIPTION
* When running multiple commands via window rules or keybindings, the subject container might point to an old reference (eg. when going from a tiling to a floating window). To avoid this, refetch the subject container between each command invocation in a window rule or keybinding.
* Add new `Id` property to all containers. 

Closes #149 and #144.