### PR TITLE
fix: prevent overflow when attaching a new tiling window

### DIFF
--- a/GlazeWM.Domain/Containers/CommandHandlers/AttachAndResizeContainerHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/AttachAndResizeContainerHandler.cs
@@ -26,15 +26,11 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
       _bus.Invoke(new AttachContainerCommand(childToAdd, targetParent, targetIndex));
 
       var resizableSiblings = childToAdd.SiblingsOfType<IResizable>();
-
       var defaultPercent = 1.0 / (resizableSiblings.Count() + 1);
-      (childToAdd as IResizable).SizePercentage = defaultPercent;
 
-      var sizePercentageDecrement = defaultPercent / resizableSiblings.Count();
-
-      // Adjust `SizePercentage` of the added container's siblings.
-      foreach (var sibling in resizableSiblings)
-        (sibling as IResizable).SizePercentage -= sizePercentageDecrement;
+      // TODO: If called with a container that has a `SizePercentage` of 1, them it gets increased to 1.5.
+      // Could instead have a `SetSizePercentageCommand`.
+      _bus.Invoke(new ResizeContainerCommand(childToAdd, defaultPercent));
 
       return CommandResponse.Ok;
     }

--- a/GlazeWM.Domain/Containers/CommandHandlers/AttachAndResizeContainerHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/AttachAndResizeContainerHandler.cs
@@ -26,8 +26,12 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
       _bus.Invoke(new AttachContainerCommand(childToAdd, targetParent, targetIndex));
 
       var resizableSiblings = childToAdd.SiblingsOfType<IResizable>();
+
       if (!resizableSiblings.Any())
+      {
+        (childToAdd as IResizable).SizePercentage = 1;
         return CommandResponse.Ok;
+      }
 
       var defaultPercent = 1.0 / (resizableSiblings.Count() + 1);
 

--- a/GlazeWM.Domain/Containers/CommandHandlers/AttachAndResizeContainerHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/AttachAndResizeContainerHandler.cs
@@ -26,10 +26,13 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
       _bus.Invoke(new AttachContainerCommand(childToAdd, targetParent, targetIndex));
 
       var resizableSiblings = childToAdd.SiblingsOfType<IResizable>();
+      if (!resizableSiblings.Any())
+        return CommandResponse.Ok;
+
       var defaultPercent = 1.0 / (resizableSiblings.Count() + 1);
 
-      // TODO: If called with a container that has a `SizePercentage` of 1, them it gets increased to 1.5.
-      // Could instead have a `SetSizePercentageCommand`.
+      // Set initial size percentage to 0, and then size up the container to `defaultPercent`.
+      (childToAdd as IResizable).SizePercentage = 0;
       _bus.Invoke(new ResizeContainerCommand(childToAdd, defaultPercent));
 
       return CommandResponse.Ok;

--- a/GlazeWM.Domain/Containers/CommandHandlers/ChangeContainerLayoutHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/ChangeContainerLayoutHandler.cs
@@ -64,8 +64,10 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
       // the split container after the replacement.
       _bus.Invoke(new ReplaceContainerCommand(splitContainer, parent, window.Index));
 
+      // The child window takes up the full size of its parent split container.
+      (window as IResizable).SizePercentage = 1;
       _bus.Invoke(new DetachContainerCommand(window));
-      _bus.Invoke(new AttachAndResizeContainerCommand(window, splitContainer));
+      _bus.Invoke(new AttachContainerCommand(window, splitContainer));
     }
 
     private void ChangeWorkspaceLayout(Workspace workspace, Layout newLayout)

--- a/GlazeWM.Domain/Containers/CommandHandlers/DetachAndResizeContainerHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/DetachAndResizeContainerHandler.cs
@@ -24,8 +24,10 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
       if (childToRemove is not IResizable)
         throw new Exception("Cannot resize a non-resizable container. This is a bug.");
 
-      var isEmptySplitContainer = parent is SplitContainer && parent.Children.Count == 1
-        && parent is not Workspace;
+      var isEmptySplitContainer =
+        parent is SplitContainer &&
+        parent.Children.Count == 1 &&
+        parent is not Workspace;
 
       // Get the freed up space after container is detached.
       var availableSizePercentage = isEmptySplitContainer
@@ -34,8 +36,8 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
 
       // Resize children of grandparent if `childToRemove`'s parent is also to be detached.
       var containersToResize = isEmptySplitContainer
-        ? grandparent.Children.Where(container => container is IResizable)
-        : parent.Children.Where(container => container is IResizable);
+        ? grandparent.ChildrenOfType<IResizable>()
+        : parent.ChildrenOfType<IResizable>();
 
       _bus.Invoke(new DetachContainerCommand(childToRemove));
 

--- a/GlazeWM.Domain/Containers/CommandHandlers/ResizeContainerHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/ResizeContainerHandler.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GlazeWM.Domain.Containers.Commands;
+using GlazeWM.Infrastructure.Bussing;
+
+namespace GlazeWM.Domain.Containers.CommandHandlers
+{
+  internal class ResizeContainerHandler : ICommandHandler<ResizeContainerCommand>
+  {
+    private const double MIN_SIZE_PERCENTAGE = 0.01;
+
+    public CommandResponse Handle(ResizeContainerCommand command)
+    {
+      var containerToResize = command.ContainerToResize;
+      var resizePercentage = command.ResizePercentage;
+
+      var resizableSiblings = containerToResize.SiblingsOfType<IResizable>();
+
+      // Ignore cases where the container to resize is a workspace or the only child.
+      // if (!resizableSiblings.Any() || containerToResize is Workspace)
+      //   return CommandResponse.Ok;
+
+      // Get available size percentage amongst siblings.
+      var availableSizePercentage = GetAvailableSizePercentage(
+        resizableSiblings
+      );
+
+      // Prevent window from being smaller than the minimum and larger than space available from
+      // sibling containers.
+      var minResizeDelta = MIN_SIZE_PERCENTAGE - (containerToResize as IResizable).SizePercentage;
+      var clampedResizePercentage = Math.Clamp(
+        resizePercentage,
+        minResizeDelta,
+        availableSizePercentage
+      );
+
+      // Resize the container and distribute the size percentage amongst its siblings.
+      (containerToResize as IResizable).SizePercentage += clampedResizePercentage;
+      DistributeSizePercentage(resizableSiblings, clampedResizePercentage, availableSizePercentage);
+
+      return CommandResponse.Ok;
+    }
+
+    private static double GetAvailableSizePercentage(IEnumerable<Container> containers)
+    {
+      return containers.Aggregate(
+        0.0,
+        (sum, container) => sum + (container as IResizable).SizePercentage - MIN_SIZE_PERCENTAGE
+      );
+    }
+
+    private static void DistributeSizePercentage(
+      IEnumerable<Container> containers,
+      double sizePercentage,
+      double availableSizePercentage)
+    {
+      foreach (var container in containers)
+      {
+        var conAvailableSizePercentage =
+          (container as IResizable).SizePercentage - MIN_SIZE_PERCENTAGE;
+
+        // Get percentage of resize that affects this container. `availableSizePercentage`
+        // can be 0 here when the main container to resize is shrunk from max size percentage.
+        var resizeFactor = availableSizePercentage == 0.0
+          ? 1.0 / containers.Count()
+          : conAvailableSizePercentage / availableSizePercentage;
+
+        (container as IResizable).SizePercentage -= resizeFactor * sizePercentage;
+      }
+    }
+  }
+}

--- a/GlazeWM.Domain/Containers/CommandHandlers/ResizeContainerHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/ResizeContainerHandler.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using GlazeWM.Domain.Containers.Commands;
+using GlazeWM.Domain.Workspaces;
 using GlazeWM.Infrastructure.Bussing;
 
 namespace GlazeWM.Domain.Containers.CommandHandlers
@@ -18,8 +19,8 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
       var resizableSiblings = containerToResize.SiblingsOfType<IResizable>();
 
       // Ignore cases where the container to resize is a workspace or the only child.
-      // if (!resizableSiblings.Any() || containerToResize is Workspace)
-      //   return CommandResponse.Ok;
+      if (!resizableSiblings.Any() || containerToResize is Workspace)
+        return CommandResponse.Ok;
 
       // Get available size percentage amongst siblings.
       var availableSizePercentage = GetAvailableSizePercentage(

--- a/GlazeWM.Domain/Containers/Commands/ResizeContainerCommand.cs
+++ b/GlazeWM.Domain/Containers/Commands/ResizeContainerCommand.cs
@@ -1,0 +1,16 @@
+﻿using GlazeWM.Infrastructure.Bussing;
+
+namespace GlazeWM.Domain.Containers.Commands
+{
+  public class ResizeContainerCommand : Command
+  {
+    public Container ContainerToResize { get; }
+    public double ResizePercentage { get; }
+
+    public ResizeContainerCommand(Container containerToResize, double resizePercentage)
+    {
+      ContainerToResize = containerToResize;
+      ResizePercentage = resizePercentage;
+    }
+  }
+}

--- a/GlazeWM.Domain/DependencyInjection.cs
+++ b/GlazeWM.Domain/DependencyInjection.cs
@@ -46,6 +46,7 @@ namespace GlazeWM.Domain
       services.AddSingleton<ICommandHandler<MoveContainerWithinTreeCommand>, MoveContainerWithinTreeHandler>();
       services.AddSingleton<ICommandHandler<RedrawContainersCommand>, RedrawContainersHandler>();
       services.AddSingleton<ICommandHandler<ReplaceContainerCommand>, ReplaceContainerHandler>();
+      services.AddSingleton<ICommandHandler<ResizeContainerCommand>, ResizeContainerHandler>();
       services.AddSingleton<ICommandHandler<SetFocusedDescendantCommand>, SetFocusedDescendantHandler>();
       services.AddSingleton<ICommandHandler<SetNativeFocusCommand>, SetNativeFocusHandler>();
       services.AddSingleton<ICommandHandler<ToggleFocusModeCommand>, ToggleFocusModeHandler>();

--- a/GlazeWM.Domain/Windows/CommandHandlers/ResizeWindowHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/ResizeWindowHandler.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;


### PR DESCRIPTION
* Previously when attaching a tiling window, all sibling windows would be resized by the same amount. This could cause a sibling window to have a negative `SizePercentage`. After the change, siblings are resized when attaching by a factor of their previous `SizePercentage`.