### PR TITLE
feat: add "focus workspace toggle" command

### DIFF
--- a/GlazeWM.Bootstrapper/sample-config.yaml
+++ b/GlazeWM.Bootstrapper/sample-config.yaml
@@ -115,9 +115,13 @@ keybindings:
   - command: "exec cmd"
     binding: "Alt+Enter"
 
-  # Focus the workspace that last had focus.
+  # Focus the workspace that had earlier focus.
   - command: "focus workspace recent"
     binding: "Alt+R"
+  
+  # Toggle focus to the most recent workspace.
+  - command: "focus workspace toggle"
+    binding: "Alt+Oemtilde"
 
   # Focus the next/previous workspace defined in `workspaces` config.
   - command: "focus workspace next"

--- a/GlazeWM.Domain/Common/Utils/Keywords.cs
+++ b/GlazeWM.Domain/Common/Utils/Keywords.cs
@@ -8,6 +8,6 @@ namespace GlazeWM.Domain.Common.Utils
     /// Keywords that are part of the "focus workspace" commands
     /// Keywords cannot be used as a workspace name
     /// </summary>
-    public static HashSet<string> WorkspaceKeyswords = new HashSet<string>() { "prev", "next", "recent" };
+    public static HashSet<string> WorkspaceKeyswords = new HashSet<string>() { "prev", "next", "recent", "toggle" };
   }
 }

--- a/GlazeWM.Domain/DependencyInjection.cs
+++ b/GlazeWM.Domain/DependencyInjection.cs
@@ -74,6 +74,7 @@ namespace GlazeWM.Domain
       services.AddSingleton<ICommandHandler<DeactivateWorkspaceCommand>, DeactivateWorkspaceHandler>();
       services.AddSingleton<ICommandHandler<FocusWorkspaceCommand>, FocusWorkspaceHandler>();
       services.AddSingleton<ICommandHandler<FocusWorkspaceRecentCommand>, FocusWorkspaceRecentHandler>();
+      services.AddSingleton<ICommandHandler<FocusWorkspaceToggleCommand>, FocusWorkspaceToggleHandler>();
       services.AddSingleton<ICommandHandler<FocusWorkspaceSequenceCommand>, FocusWorkspaceSequenceHandler>();
       services.AddSingleton<ICommandHandler<MoveWindowToWorkspaceCommand>, MoveWindowToWorkspaceHandler>();
       services.AddSingleton<ICommandHandler<UpdateWorkspacesFromConfigCommand>, UpdateWorkspacesFromConfigHandler>();

--- a/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
+++ b/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
@@ -126,6 +126,7 @@ namespace GlazeWM.Domain.UserConfigs
         "recent" => new FocusWorkspaceRecentCommand(),
         "prev" => new FocusWorkspaceSequenceCommand(Sequence.PREVIOUS),
         "next" => new FocusWorkspaceSequenceCommand(Sequence.NEXT),
+        "toggle" => new FocusWorkspaceToggleCommand(),
         // errors already checked at the previous level parsing
         _  => new FocusWorkspaceCommand(commandParts[2]),
       };

--- a/GlazeWM.Domain/Workspaces/CommandHandlers/FocusWorkspaceHandler.cs
+++ b/GlazeWM.Domain/Workspaces/CommandHandlers/FocusWorkspaceHandler.cs
@@ -49,6 +49,9 @@ namespace GlazeWM.Domain.Workspaces.CommandHandlers
       // Save currently focused workspace as recent for command "recent"
       _workspaceService.PushRecentWorkspace(focusedWorkspace);
 
+      // Save the currently focused workspace as most recent, used for toggling workspaces
+      _workspaceService.MostRecentWorkspace = focusedWorkspace;
+
       // Set focus to the last focused window in workspace. If the workspace has no descendant
       // windows, then set focus to the workspace itself.
       var containerToFocus = workspaceToFocus.HasChildren()

--- a/GlazeWM.Domain/Workspaces/CommandHandlers/FocusWorkspaceToggleHandler.cs
+++ b/GlazeWM.Domain/Workspaces/CommandHandlers/FocusWorkspaceToggleHandler.cs
@@ -1,0 +1,47 @@
+﻿using System.Linq;
+using GlazeWM.Domain.UserConfigs;
+using GlazeWM.Domain.Workspaces.Commands;
+using GlazeWM.Infrastructure.Bussing;
+
+namespace GlazeWM.Domain.Workspaces.CommandHandlers
+{
+  internal class FocusWorkspaceToggleHandler : ICommandHandler<FocusWorkspaceToggleCommand>
+  {
+    private readonly Bus _bus;
+    private readonly UserConfigService _userConfigService;
+    private readonly WorkspaceService _workspaceService;
+
+    public FocusWorkspaceToggleHandler(
+      Bus bus,
+      UserConfigService userConfigService,
+      WorkspaceService workspaceService)
+    {
+      _bus = bus;
+      _userConfigService = userConfigService;
+      _workspaceService = workspaceService;
+    }
+
+    public CommandResponse Handle(FocusWorkspaceToggleCommand command)
+    {
+      var mostRecentWorkspace = _workspaceService.MostRecentWorkspace;
+      var currentWorkspace = _workspaceService.GetFocusedWorkspace();
+      var workspaceConfigs = _userConfigService.WorkspaceConfigs;
+
+      if (mostRecentWorkspace != null)
+      {
+        // Validate that workspace are still available
+        if (workspaceConfigs.Any(workspace => workspace.Name == mostRecentWorkspace.Name))
+        {
+          // Focus workspace
+          _bus.Invoke(new FocusWorkspaceCommand(mostRecentWorkspace.Name));
+          // Update most recent workspace
+          _workspaceService.MostRecentWorkspace = currentWorkspace;
+
+          return CommandResponse.Ok;
+        }
+      }
+
+      return CommandResponse.Fail;
+    }
+  }
+}

--- a/GlazeWM.Domain/Workspaces/Commands/FocusWorkspaceToggleCommand.cs
+++ b/GlazeWM.Domain/Workspaces/Commands/FocusWorkspaceToggleCommand.cs
@@ -1,0 +1,6 @@
+﻿using GlazeWM.Infrastructure.Bussing;
+
+namespace GlazeWM.Domain.Workspaces.Commands
+{
+  public class FocusWorkspaceToggleCommand : Command { }
+}

--- a/GlazeWM.Domain/Workspaces/WorkspaceService.cs
+++ b/GlazeWM.Domain/Workspaces/WorkspaceService.cs
@@ -12,6 +12,7 @@ namespace GlazeWM.Domain.Workspaces
     private readonly UserConfigService _userConfigService;
 
     private readonly Stack<Workspace> _recentWorkspaces = new();
+    public Workspace MostRecentWorkspace { get; set; }
 
     public WorkspaceService(ContainerService containerService, UserConfigService userConfigService)
     {

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ window_rules:
 
 - layout \<vertical | horizontal>
 - focus \<left | right | up | down>
-- focus workspace \<prev | next | recent>
+- focus workspace \<prev | next | recent | toggle>
 - focus workspace \<workspace name>
 - move \<left | right | up | down>
 - move to workspace \<workspace name>


### PR DESCRIPTION
This pull request adds the ability to toggle focus between the current workspace and the most recent workspace using a new command, `focus workspace toggle`.

These updates are modeled on #160. The functionality is similar, but `focus workspace recent` is more like an "undo" command. For example, say you focus workspace 1, then workspace 2, then workspace 3. Calling `focus workspace recent` twice would:
1. focus workspace 2
2. focus workspace 1

In contrast, `focus workspace toggle` twice would:
1. focus workspace 2
2. focus workspace 3

(and would continue to toggle until a different workspace is selected).