### PR TITLE
Made "focus workspace recent" a toggle

### DIFF
--- a/GlazeWM.Domain/Workspaces/CommandHandlers/FocusWorkspaceHandler.cs
+++ b/GlazeWM.Domain/Workspaces/CommandHandlers/FocusWorkspaceHandler.cs
@@ -47,7 +47,7 @@ namespace GlazeWM.Domain.Workspaces.CommandHandlers
         return CommandResponse.Ok;
 
       // Save currently focused workspace as recent for command "recent"
-      _workspaceService.PushRecentWorkspace(focusedWorkspace);
+      _workspaceService.MostRecentWorkspace = focusedWorkspace;
 
       // Set focus to the last focused window in workspace. If the workspace has no descendant
       // windows, then set focus to the workspace itself.

--- a/GlazeWM.Domain/Workspaces/CommandHandlers/FocusWorkspaceRecentHandler.cs
+++ b/GlazeWM.Domain/Workspaces/CommandHandlers/FocusWorkspaceRecentHandler.cs
@@ -23,23 +23,22 @@ namespace GlazeWM.Domain.Workspaces.CommandHandlers
 
     public CommandResponse Handle(FocusWorkspaceRecentCommand command)
     {
-      var recentWorkspace = _workspaceService.PopRecentWorkspace();
+      var mostRecentWorkspace = _workspaceService.MostRecentWorkspace;
+      var currentWorkspace = _workspaceService.GetFocusedWorkspace();
       var workspaceConfigs = _userConfigService.WorkspaceConfigs;
 
-      while (recentWorkspace != null)
+      if (mostRecentWorkspace != null)
       {
         // Validate that workspace are still available
-        if (workspaceConfigs.Any(workspace => workspace.Name == recentWorkspace.Name))
+        if (workspaceConfigs.Any(workspace => workspace.Name == mostRecentWorkspace.Name))
         {
           // Focus workspace
-          _bus.Invoke(new FocusWorkspaceCommand(recentWorkspace.Name));
-          // Remove last entry so as not to get stuck 
-          _workspaceService.PopRecentWorkspace();
+          _bus.Invoke(new FocusWorkspaceCommand(mostRecentWorkspace.Name));
+          // Update most recent workspace
+          _workspaceService.MostRecentWorkspace = currentWorkspace;
 
           return CommandResponse.Ok;
         }
-
-        recentWorkspace = _workspaceService.PopRecentWorkspace();
       }
 
       return CommandResponse.Fail;

--- a/GlazeWM.Domain/Workspaces/WorkspaceService.cs
+++ b/GlazeWM.Domain/Workspaces/WorkspaceService.cs
@@ -11,7 +11,7 @@ namespace GlazeWM.Domain.Workspaces
     private readonly ContainerService _containerService;
     private readonly UserConfigService _userConfigService;
 
-    private readonly Stack<Workspace> _recentWorkspaces = new();
+    public Workspace MostRecentWorkspace { get; set; }
 
     public WorkspaceService(ContainerService containerService, UserConfigService userConfigService)
     {
@@ -69,20 +69,6 @@ namespace GlazeWM.Domain.Workspaces
     public Workspace GetFocusedWorkspace()
     {
       return GetWorkspaceFromChildContainer(_containerService.FocusedContainer);
-    }
-
-    public Workspace PopRecentWorkspace()
-    {
-      if (_recentWorkspaces.Count > 0)
-      {
-        return _recentWorkspaces.Pop();
-      }
-      return null;
-    }
-
-    public void PushRecentWorkspace(Workspace workspace)
-    {
-      _recentWorkspaces.Push(workspace);
     }
   }
 }


### PR DESCRIPTION
Per #178, updates the "focus workspace recent" command to toggle between workspaces (instead of undo-like functionality).