### PR TITLE
fix: invalid reference after ignore window rule

### DIFF
--- a/GlazeWM.Domain/Windows/CommandHandlers/RunWindowRulesHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/RunWindowRulesHandler.cs
@@ -36,7 +36,8 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
 
       foreach (var commandString in commandStrings)
       {
-        if (subjectWindow.IsDetached())
+        // Subject window might be null if "ignore" rule has run.
+        if (subjectWindow?.IsDetached() != false)
           return CommandResponse.Ok;
 
         var parsedCommand = _commandParsingService.ParseCommand(commandString, subjectWindow);


### PR DESCRIPTION
* Fix crash where window rules are run after a window has been ignored (eg. `["ignore", "set floating"]`)