### PR TITLE
feat: bar transparency via RGBA

### DIFF
--- a/GlazeWM.Bar/BarService.cs
+++ b/GlazeWM.Bar/BarService.cs
@@ -107,25 +107,5 @@ namespace GlazeWM.Bar
         barWindow.Close();
       });
     }
-
-    /// <summary>
-    /// Convert shorthand properties from user config (ie. `Padding`, `Margin`, and `BorderWidth`)
-    /// to be compatible with their equivalent XAML properties (ie. `Padding`, `Margin`, and
-    /// `BorderThickness`). Shorthand properties follow the 1-to-4 value syntax used in CSS.
-    /// </summary>
-    /// <exception cref="ArgumentException"></exception>
-    public static string ShorthandToXamlProperty(string shorthand)
-    {
-      var shorthandParts = shorthand.Split(" ");
-
-      return shorthandParts.Length switch
-      {
-        1 => shorthand,
-        2 => $"{shorthandParts[1]},{shorthandParts[0]},{shorthandParts[1]},{shorthandParts[0]}",
-        3 => $"{shorthandParts[1]},{shorthandParts[0]},{shorthandParts[1]},{shorthandParts[2]}",
-        4 => $"{shorthandParts[3]},{shorthandParts[0]},{shorthandParts[1]},{shorthandParts[2]}",
-        _ => throw new ArgumentException(null, nameof(shorthand)),
-      };
-    }
   }
 }

--- a/GlazeWM.Bar/BarViewModel.cs
+++ b/GlazeWM.Bar/BarViewModel.cs
@@ -25,8 +25,8 @@ namespace GlazeWM.Bar
     public string FontWeight => _barConfig.FontWeight;
     public string FontSize => _barConfig.FontSize;
     public string BorderColor => _barConfig.BorderColor;
-    public string BorderWidth => BarService.ShorthandToXamlProperty(_barConfig.BorderWidth);
-    public string Padding => BarService.ShorthandToXamlProperty(_barConfig.Padding);
+    public string BorderWidth => XamlHelper.ShorthandToXamlProperty(_barConfig.BorderWidth);
+    public string Padding => XamlHelper.ShorthandToXamlProperty(_barConfig.Padding);
     public double Opacity => _barConfig.Opacity;
 
     public List<ComponentViewModel> ComponentsLeft =>

--- a/GlazeWM.Bar/BarViewModel.cs
+++ b/GlazeWM.Bar/BarViewModel.cs
@@ -19,14 +19,14 @@ namespace GlazeWM.Bar
     private BarConfig _barConfig => _userConfigService.BarConfig;
 
     public BarPosition Position => _barConfig.Position;
-    public string Background => XamlHelper.FormatXamlColor(_barConfig.Background);
-    public string Foreground => XamlHelper.FormatXamlColor(_barConfig.Foreground);
+    public string Background => XamlHelper.FormatColor(_barConfig.Background);
+    public string Foreground => XamlHelper.FormatColor(_barConfig.Foreground);
     public string FontFamily => _barConfig.FontFamily;
     public string FontWeight => _barConfig.FontWeight;
     public string FontSize => _barConfig.FontSize;
-    public string BorderColor => XamlHelper.FormatXamlColor(_barConfig.BorderColor);
-    public string BorderWidth => XamlHelper.ShorthandToXamlProperty(_barConfig.BorderWidth);
-    public string Padding => XamlHelper.ShorthandToXamlProperty(_barConfig.Padding);
+    public string BorderColor => XamlHelper.FormatColor(_barConfig.BorderColor);
+    public string BorderWidth => XamlHelper.FormatRectShorthand(_barConfig.BorderWidth);
+    public string Padding => XamlHelper.FormatRectShorthand(_barConfig.Padding);
     public double Opacity => _barConfig.Opacity;
 
     public List<ComponentViewModel> ComponentsLeft =>

--- a/GlazeWM.Bar/BarViewModel.cs
+++ b/GlazeWM.Bar/BarViewModel.cs
@@ -19,12 +19,12 @@ namespace GlazeWM.Bar
     private BarConfig _barConfig => _userConfigService.BarConfig;
 
     public BarPosition Position => _barConfig.Position;
-    public string Background => _barConfig.Background;
-    public string Foreground => _barConfig.Foreground;
+    public string Background => XamlHelper.FormatXamlColor(_barConfig.Background);
+    public string Foreground => XamlHelper.FormatXamlColor(_barConfig.Foreground);
     public string FontFamily => _barConfig.FontFamily;
     public string FontWeight => _barConfig.FontWeight;
     public string FontSize => _barConfig.FontSize;
-    public string BorderColor => _barConfig.BorderColor;
+    public string BorderColor => XamlHelper.FormatXamlColor(_barConfig.BorderColor);
     public string BorderWidth => XamlHelper.ShorthandToXamlProperty(_barConfig.BorderWidth);
     public string Padding => XamlHelper.ShorthandToXamlProperty(_barConfig.Padding);
     public double Opacity => _barConfig.Opacity;

--- a/GlazeWM.Bar/Components/ComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/ComponentViewModel.cs
@@ -8,12 +8,16 @@ namespace GlazeWM.Bar.Components
     protected readonly BarViewModel _parentViewModel;
     protected readonly BarComponentConfig _componentConfig;
 
-    public string Background => _componentConfig.Background ?? _parentViewModel.Background;
-    public string Foreground => _componentConfig.Foreground ?? _parentViewModel.Foreground;
+    public string Background => XamlHelper.FormatXamlColor(
+      _componentConfig.Background ?? _parentViewModel.Background
+    );
+    public string Foreground => XamlHelper.FormatXamlColor(
+      _componentConfig.Foreground ?? _parentViewModel.Foreground
+    );
     public string FontFamily => _componentConfig.FontFamily ?? _parentViewModel.FontFamily;
     public string FontWeight => _componentConfig.FontWeight ?? _parentViewModel.FontWeight;
     public string FontSize => _componentConfig.FontSize ?? _parentViewModel.FontSize;
-    public string BorderColor => _componentConfig.BorderColor;
+    public string BorderColor => XamlHelper.FormatXamlColor(_componentConfig.BorderColor);
     public string BorderWidth => XamlHelper.ShorthandToXamlProperty(_componentConfig.BorderWidth);
     public string Padding => XamlHelper.ShorthandToXamlProperty(_componentConfig.Padding);
     public string Margin => XamlHelper.ShorthandToXamlProperty(_componentConfig.Margin);

--- a/GlazeWM.Bar/Components/ComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/ComponentViewModel.cs
@@ -14,9 +14,9 @@ namespace GlazeWM.Bar.Components
     public string FontWeight => _componentConfig.FontWeight ?? _parentViewModel.FontWeight;
     public string FontSize => _componentConfig.FontSize ?? _parentViewModel.FontSize;
     public string BorderColor => _componentConfig.BorderColor;
-    public string BorderWidth => BarService.ShorthandToXamlProperty(_componentConfig.BorderWidth);
-    public string Padding => BarService.ShorthandToXamlProperty(_componentConfig.Padding);
-    public string Margin => BarService.ShorthandToXamlProperty(_componentConfig.Margin);
+    public string BorderWidth => XamlHelper.ShorthandToXamlProperty(_componentConfig.BorderWidth);
+    public string Padding => XamlHelper.ShorthandToXamlProperty(_componentConfig.Padding);
+    public string Margin => XamlHelper.ShorthandToXamlProperty(_componentConfig.Margin);
 
     public ComponentViewModel(BarViewModel parentViewModel, BarComponentConfig baseConfig)
     {

--- a/GlazeWM.Bar/Components/ComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/ComponentViewModel.cs
@@ -8,19 +8,19 @@ namespace GlazeWM.Bar.Components
     protected readonly BarViewModel _parentViewModel;
     protected readonly BarComponentConfig _componentConfig;
 
-    public string Background => XamlHelper.FormatXamlColor(
+    public string Background => XamlHelper.FormatColor(
       _componentConfig.Background ?? _parentViewModel.Background
     );
-    public string Foreground => XamlHelper.FormatXamlColor(
+    public string Foreground => XamlHelper.FormatColor(
       _componentConfig.Foreground ?? _parentViewModel.Foreground
     );
     public string FontFamily => _componentConfig.FontFamily ?? _parentViewModel.FontFamily;
     public string FontWeight => _componentConfig.FontWeight ?? _parentViewModel.FontWeight;
     public string FontSize => _componentConfig.FontSize ?? _parentViewModel.FontSize;
-    public string BorderColor => XamlHelper.FormatXamlColor(_componentConfig.BorderColor);
-    public string BorderWidth => XamlHelper.ShorthandToXamlProperty(_componentConfig.BorderWidth);
-    public string Padding => XamlHelper.ShorthandToXamlProperty(_componentConfig.Padding);
-    public string Margin => XamlHelper.ShorthandToXamlProperty(_componentConfig.Margin);
+    public string BorderColor => XamlHelper.FormatColor(_componentConfig.BorderColor);
+    public string BorderWidth => XamlHelper.FormatRectShorthand(_componentConfig.BorderWidth);
+    public string Padding => XamlHelper.FormatRectShorthand(_componentConfig.Padding);
+    public string Margin => XamlHelper.FormatRectShorthand(_componentConfig.Margin);
 
     public ComponentViewModel(BarViewModel parentViewModel, BarComponentConfig baseConfig)
     {

--- a/GlazeWM.Bar/Components/ComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/ComponentViewModel.cs
@@ -8,17 +8,17 @@ namespace GlazeWM.Bar.Components
     protected readonly BarViewModel _parentViewModel;
     protected readonly BarComponentConfig _componentConfig;
 
-    public string Background => XamlHelper.FormatColor(
-      _componentConfig.Background ?? _parentViewModel.Background
-    );
-    public string Foreground => XamlHelper.FormatColor(
-      _componentConfig.Foreground ?? _parentViewModel.Foreground
-    );
-    public string FontFamily => _componentConfig.FontFamily ?? _parentViewModel.FontFamily;
-    public string FontWeight => _componentConfig.FontWeight ?? _parentViewModel.FontWeight;
+    public string Background => XamlHelper.FormatColor(_componentConfig.Background);
+    public string Foreground =>
+      XamlHelper.FormatColor(_componentConfig.Foreground ?? _parentViewModel.Foreground);
+    public string FontFamily =>
+      _componentConfig.FontFamily ?? _parentViewModel.FontFamily;
+    public string FontWeight =>
+      _componentConfig.FontWeight ?? _parentViewModel.FontWeight;
     public string FontSize => _componentConfig.FontSize ?? _parentViewModel.FontSize;
     public string BorderColor => XamlHelper.FormatColor(_componentConfig.BorderColor);
-    public string BorderWidth => XamlHelper.FormatRectShorthand(_componentConfig.BorderWidth);
+    public string BorderWidth =>
+      XamlHelper.FormatRectShorthand(_componentConfig.BorderWidth);
     public string Padding => XamlHelper.FormatRectShorthand(_componentConfig.Padding);
     public string Margin => XamlHelper.FormatRectShorthand(_componentConfig.Margin);
 

--- a/GlazeWM.Bar/Components/WorkspacesComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/WorkspacesComponentViewModel.cs
@@ -60,7 +60,7 @@ namespace GlazeWM.Bar.Components
       XamlHelper.FormatRectShorthand(_config.DisplayedWorkspaceBorderWidth);
 
     public string DefaultWorkspaceBackground =>
-      XamlHelper.FormatColor(_config.DefaultWorkspaceBackground ?? Background);
+      XamlHelper.FormatColor(_config.DefaultWorkspaceBackground);
     public string DefaultWorkspaceForeground =>
       XamlHelper.FormatColor(_config.DefaultWorkspaceForeground ?? Foreground);
     public string DefaultWorkspaceBorderColor =>

--- a/GlazeWM.Bar/Components/WorkspacesComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/WorkspacesComponentViewModel.cs
@@ -21,7 +21,8 @@ namespace GlazeWM.Bar.Components
   {
     private Dispatcher _dispatcher => _parentViewModel.Dispatcher;
     private Monitor _monitor => _parentViewModel.Monitor;
-    private WorkspacesComponentConfig _config => _componentConfig as WorkspacesComponentConfig;
+    private WorkspacesComponentConfig _config =>
+      _componentConfig as WorkspacesComponentConfig;
     private readonly Bus _bus = ServiceLocator.GetRequiredService<Bus>();
     private readonly UserConfigService _userConfigService =
      ServiceLocator.GetRequiredService<UserConfigService>();
@@ -29,7 +30,8 @@ namespace GlazeWM.Bar.Components
     public ObservableCollection<Workspace> Workspaces => new(_orderedWorkspaces);
 
     /// <summary>
-    /// Get workspaces of the current monitor sorted in the order they appear in the user's config.
+    /// Get workspaces of the current monitor sorted in the order they appear in the
+    /// user's config.
     /// </summary>
     private IEnumerable<Workspace> _orderedWorkspaces => _monitor.Children
       .Cast<Workspace>()
@@ -39,21 +41,30 @@ namespace GlazeWM.Bar.Components
         )
       );
 
-    public string FocusedWorkspaceBackground => _config.FocusedWorkspaceBackground;
-    public string FocusedWorkspaceForeground => _config.FocusedWorkspaceForeground ?? Foreground;
-    public string FocusedWorkspaceBorderColor => _config.FocusedWorkspaceBorderColor;
+    public string FocusedWorkspaceBackground =>
+      XamlHelper.FormatColor(_config.FocusedWorkspaceBackground);
+    public string FocusedWorkspaceForeground =>
+      XamlHelper.FormatColor(_config.FocusedWorkspaceForeground ?? Foreground);
+    public string FocusedWorkspaceBorderColor =>
+      XamlHelper.FormatColor(_config.FocusedWorkspaceBorderColor);
     public string FocusedWorkspaceBorderWidth =>
       XamlHelper.FormatRectShorthand(_config.FocusedWorkspaceBorderWidth);
 
-    public string DisplayedWorkspaceBackground => _config.DisplayedWorkspaceBackground;
-    public string DisplayedWorkspaceForeground => _config.DisplayedWorkspaceForeground ?? Foreground;
-    public string DisplayedWorkspaceBorderColor => _config.DisplayedWorkspaceBorderColor;
+    public string DisplayedWorkspaceBackground =>
+      XamlHelper.FormatColor(_config.DisplayedWorkspaceBackground);
+    public string DisplayedWorkspaceForeground =>
+      XamlHelper.FormatColor(_config.DisplayedWorkspaceForeground ?? Foreground);
+    public string DisplayedWorkspaceBorderColor =>
+      XamlHelper.FormatColor(_config.DisplayedWorkspaceBorderColor);
     public string DisplayedWorkspaceBorderWidth =>
       XamlHelper.FormatRectShorthand(_config.DisplayedWorkspaceBorderWidth);
 
-    public string DefaultWorkspaceBackground => _config.DefaultWorkspaceBackground ?? Background;
-    public string DefaultWorkspaceForeground => _config.DefaultWorkspaceForeground ?? Foreground;
-    public string DefaultWorkspaceBorderColor => _config.DefaultWorkspaceBorderColor;
+    public string DefaultWorkspaceBackground =>
+      XamlHelper.FormatColor(_config.DefaultWorkspaceBackground ?? Background);
+    public string DefaultWorkspaceForeground =>
+      XamlHelper.FormatColor(_config.DefaultWorkspaceForeground ?? Foreground);
+    public string DefaultWorkspaceBorderColor =>
+      XamlHelper.FormatColor(_config.DefaultWorkspaceBorderColor);
     public string DefaultWorkspaceBorderWidth =>
       XamlHelper.FormatRectShorthand(_config.DefaultWorkspaceBorderWidth);
 
@@ -64,7 +75,9 @@ namespace GlazeWM.Bar.Components
       WorkspacesComponentConfig config) : base(parentViewModel, config)
     {
       var workspacesChangedEvent = _bus.Events.Where((@event) =>
-        @event is WorkspaceActivatedEvent or WorkspaceDeactivatedEvent or FocusChangedEvent
+        @event is WorkspaceActivatedEvent
+          or WorkspaceDeactivatedEvent
+          or FocusChangedEvent
       );
 
       // Refresh contents of workspaces collection.

--- a/GlazeWM.Bar/Components/WorkspacesComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/WorkspacesComponentViewModel.cs
@@ -43,19 +43,19 @@ namespace GlazeWM.Bar.Components
     public string FocusedWorkspaceForeground => _config.FocusedWorkspaceForeground ?? Foreground;
     public string FocusedWorkspaceBorderColor => _config.FocusedWorkspaceBorderColor;
     public string FocusedWorkspaceBorderWidth =>
-      XamlHelper.ShorthandToXamlProperty(_config.FocusedWorkspaceBorderWidth);
+      XamlHelper.FormatRectShorthand(_config.FocusedWorkspaceBorderWidth);
 
     public string DisplayedWorkspaceBackground => _config.DisplayedWorkspaceBackground;
     public string DisplayedWorkspaceForeground => _config.DisplayedWorkspaceForeground ?? Foreground;
     public string DisplayedWorkspaceBorderColor => _config.DisplayedWorkspaceBorderColor;
     public string DisplayedWorkspaceBorderWidth =>
-      XamlHelper.ShorthandToXamlProperty(_config.DisplayedWorkspaceBorderWidth);
+      XamlHelper.FormatRectShorthand(_config.DisplayedWorkspaceBorderWidth);
 
     public string DefaultWorkspaceBackground => _config.DefaultWorkspaceBackground ?? Background;
     public string DefaultWorkspaceForeground => _config.DefaultWorkspaceForeground ?? Foreground;
     public string DefaultWorkspaceBorderColor => _config.DefaultWorkspaceBorderColor;
     public string DefaultWorkspaceBorderWidth =>
-      XamlHelper.ShorthandToXamlProperty(_config.DefaultWorkspaceBorderWidth);
+      XamlHelper.FormatRectShorthand(_config.DefaultWorkspaceBorderWidth);
 
     public ICommand FocusWorkspaceCommand => new RelayCommand<string>(FocusWorkspace);
 

--- a/GlazeWM.Bar/Components/WorkspacesComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/WorkspacesComponentViewModel.cs
@@ -43,19 +43,19 @@ namespace GlazeWM.Bar.Components
     public string FocusedWorkspaceForeground => _config.FocusedWorkspaceForeground ?? Foreground;
     public string FocusedWorkspaceBorderColor => _config.FocusedWorkspaceBorderColor;
     public string FocusedWorkspaceBorderWidth =>
-      BarService.ShorthandToXamlProperty(_config.FocusedWorkspaceBorderWidth);
+      XamlHelper.ShorthandToXamlProperty(_config.FocusedWorkspaceBorderWidth);
 
     public string DisplayedWorkspaceBackground => _config.DisplayedWorkspaceBackground;
     public string DisplayedWorkspaceForeground => _config.DisplayedWorkspaceForeground ?? Foreground;
     public string DisplayedWorkspaceBorderColor => _config.DisplayedWorkspaceBorderColor;
     public string DisplayedWorkspaceBorderWidth =>
-      BarService.ShorthandToXamlProperty(_config.DisplayedWorkspaceBorderWidth);
+      XamlHelper.ShorthandToXamlProperty(_config.DisplayedWorkspaceBorderWidth);
 
     public string DefaultWorkspaceBackground => _config.DefaultWorkspaceBackground ?? Background;
     public string DefaultWorkspaceForeground => _config.DefaultWorkspaceForeground ?? Foreground;
     public string DefaultWorkspaceBorderColor => _config.DefaultWorkspaceBorderColor;
     public string DefaultWorkspaceBorderWidth =>
-      BarService.ShorthandToXamlProperty(_config.DefaultWorkspaceBorderWidth);
+      XamlHelper.ShorthandToXamlProperty(_config.DefaultWorkspaceBorderWidth);
 
     public ICommand FocusWorkspaceCommand => new RelayCommand<string>(FocusWorkspace);
 

--- a/GlazeWM.Bar/XamlHelper.cs
+++ b/GlazeWM.Bar/XamlHelper.cs
@@ -5,11 +5,31 @@ namespace GlazeWM.Bar
   public static class XamlHelper
   {
     /// <summary>
+    /// Convert color properties from user config (ie. `Background`, `Foreground`) to be
+    /// XAML compatible. Colors in the user config are specified in RGBA, whereas XAML
+    /// expects ARGB.
+    /// </summary>
+    // TODO: Consider naming `ColorToXaml`.
+    public static string FormatXamlColor(string color)
+    {
+      var isHexColor = color.StartsWith("#");
+
+      if (!isHexColor)
+        return color;
+
+      var rgbaHex = color.Replace("#", "");
+      var argbHex = rgbaHex.Length == 8 ? rgbaHex[6..8] + rgbaHex[0..6] : rgbaHex;
+
+      return $"#{argbHex}";
+    }
+
+    /// <summary>
     /// Convert shorthand properties from user config (ie. `Padding`, `Margin`, and `BorderWidth`)
     /// to be compatible with their equivalent XAML properties (ie. `Padding`, `Margin`, and
     /// `BorderThickness`). Shorthand properties follow the 1-to-4 value syntax used in CSS.
     /// </summary>
     /// <exception cref="ArgumentException"></exception>
+    // TODO: Consider naming `RectShorthandToXaml`.
     public static string ShorthandToXamlProperty(string shorthand)
     {
       var shorthandParts = shorthand.Split(" ");

--- a/GlazeWM.Bar/XamlHelper.cs
+++ b/GlazeWM.Bar/XamlHelper.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace GlazeWM.Bar
+{
+  public static class XamlHelper
+  {
+    /// <summary>
+    /// Convert shorthand properties from user config (ie. `Padding`, `Margin`, and `BorderWidth`)
+    /// to be compatible with their equivalent XAML properties (ie. `Padding`, `Margin`, and
+    /// `BorderThickness`). Shorthand properties follow the 1-to-4 value syntax used in CSS.
+    /// </summary>
+    /// <exception cref="ArgumentException"></exception>
+    public static string ShorthandToXamlProperty(string shorthand)
+    {
+      var shorthandParts = shorthand.Split(" ");
+
+      return shorthandParts.Length switch
+      {
+        1 => shorthand,
+        2 => $"{shorthandParts[1]},{shorthandParts[0]},{shorthandParts[1]},{shorthandParts[0]}",
+        3 => $"{shorthandParts[1]},{shorthandParts[0]},{shorthandParts[1]},{shorthandParts[2]}",
+        4 => $"{shorthandParts[3]},{shorthandParts[0]},{shorthandParts[1]},{shorthandParts[2]}",
+        _ => throw new ArgumentException(null, nameof(shorthand)),
+      };
+    }
+  }
+}

--- a/GlazeWM.Bar/XamlHelper.cs
+++ b/GlazeWM.Bar/XamlHelper.cs
@@ -5,12 +5,11 @@ namespace GlazeWM.Bar
   public static class XamlHelper
   {
     /// <summary>
-    /// Convert color properties from user config (ie. `Background`, `Foreground`) to be
-    /// XAML compatible. Colors in the user config are specified in RGBA, whereas XAML
-    /// expects ARGB.
+    /// Convert color properties from user config (eg. `Background`) to be XAML
+    /// compatible. Colors in the user config are specified in RGBA, whereas XAML expects
+    /// ARGB.
     /// </summary>
-    // TODO: Consider naming `ColorToXaml`.
-    public static string FormatXamlColor(string color)
+    public static string FormatColor(string color)
     {
       var isHexColor = color.StartsWith("#");
 
@@ -24,13 +23,13 @@ namespace GlazeWM.Bar
     }
 
     /// <summary>
-    /// Convert shorthand properties from user config (ie. `Padding`, `Margin`, and `BorderWidth`)
-    /// to be compatible with their equivalent XAML properties (ie. `Padding`, `Margin`, and
-    /// `BorderThickness`). Shorthand properties follow the 1-to-4 value syntax used in CSS.
+    /// Convert shorthand properties from user config (ie. `Padding`, `Margin`, and
+    /// `BorderWidth`) to be compatible with their equivalent XAML properties (ie.
+    /// `Padding`, `Margin`, and `BorderThickness`). Shorthand properties follow the
+    /// 1-to-4 value syntax used in CSS.
     /// </summary>
     /// <exception cref="ArgumentException"></exception>
-    // TODO: Consider naming `RectShorthandToXaml`.
-    public static string ShorthandToXamlProperty(string shorthand)
+    public static string FormatRectShorthand(string shorthand)
     {
       var shorthandParts = shorthand.Split(" ");
 

--- a/GlazeWM.Domain/UserConfigs/BarComponentConfig.cs
+++ b/GlazeWM.Domain/UserConfigs/BarComponentConfig.cs
@@ -10,9 +10,10 @@ namespace GlazeWM.Domain.UserConfigs
     public string Margin { get; set; } = "0";
 
     /// <summary>
-    /// Fallback to bar background config if unset.
+    /// Background of the bar component. Use transparent as a default, since falling back
+    /// to bar background config looks weird with nested semi-transparent backgrounds.
     /// </summary>
-    public string Background { get; set; }
+    public string Background { get; set; } = "transparent";
 
     /// <summary>
     /// Fallback to bar foreground config if unset.

--- a/GlazeWM.Domain/UserConfigs/WorkspacesComponentConfig.cs
+++ b/GlazeWM.Domain/UserConfigs/WorkspacesComponentConfig.cs
@@ -24,9 +24,10 @@ namespace GlazeWM.Domain.UserConfigs
     public string DefaultWorkspaceBorderColor { get; set; } = "blue";
 
     /// <summary>
-    /// Fallback to component background config if unset.
+    /// Use transparent as a default, since falling back to bar background config looks
+    /// weird with nested semi-transparent backgrounds.
     /// </summary>
-    public string DefaultWorkspaceBackground { get; set; }
+    public string DefaultWorkspaceBackground { get; set; } = "transparent";
 
     /// <summary>
     /// Fallback to component foreground config if unset.


### PR DESCRIPTION
* Allow transparency for color properties in the bar config to be set via RGBA instead of ARGB (since it's a far more common color format).
* Change default background colors for bar components to be transparent.