### PR TITLE
feat: improve consistency of units in config

### DIFF
--- a/GlazeWM.Bar/BarViewModel.cs
+++ b/GlazeWM.Bar/BarViewModel.cs
@@ -23,7 +23,7 @@ namespace GlazeWM.Bar
     public string Foreground => XamlHelper.FormatColor(_barConfig.Foreground);
     public string FontFamily => _barConfig.FontFamily;
     public string FontWeight => _barConfig.FontWeight;
-    public string FontSize => _barConfig.FontSize;
+    public string FontSize => XamlHelper.FormatSize(_barConfig.FontSize);
     public string BorderColor => XamlHelper.FormatColor(_barConfig.BorderColor);
     public string BorderWidth => XamlHelper.FormatRectShorthand(_barConfig.BorderWidth);
     public string Padding => XamlHelper.FormatRectShorthand(_barConfig.Padding);

--- a/GlazeWM.Bar/Components/ComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/ComponentViewModel.cs
@@ -16,7 +16,8 @@ namespace GlazeWM.Bar.Components
       _componentConfig.FontFamily ?? _parentViewModel.FontFamily;
     public string FontWeight =>
       _componentConfig.FontWeight ?? _parentViewModel.FontWeight;
-    public string FontSize => _componentConfig.FontSize ?? _parentViewModel.FontSize;
+    public string FontSize =>
+      XamlHelper.FormatSize(_componentConfig.FontSize ?? _parentViewModel.FontSize);
     public string BorderColor => XamlHelper.FormatColor(_componentConfig.BorderColor);
     public string BorderWidth =>
       XamlHelper.FormatRectShorthand(_componentConfig.BorderWidth);

--- a/GlazeWM.Bar/MainWindow.xaml.cs
+++ b/GlazeWM.Bar/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ using GlazeWM.Domain.Monitors.Events;
 using GlazeWM.Domain.UserConfigs;
 using GlazeWM.Infrastructure;
 using GlazeWM.Infrastructure.Bussing;
+using GlazeWM.Infrastructure.Utils;
 using static GlazeWM.Infrastructure.WindowsApi.WindowsApiService;
 
 namespace GlazeWM.Bar
@@ -64,7 +65,7 @@ namespace GlazeWM.Bar
     private void PositionWindow(IntPtr windowHandle)
     {
       // Since window size is set manually, need to scale up height to make window DPI responsive.
-      var barHeight = _userConfigService.BarConfig.Height;
+      var barHeight = UnitsHelper.TrimUnits(_userConfigService.BarConfig.Height);
       var scaledBarHeight = Convert.ToInt32(barHeight * _monitor.ScaleFactor);
 
       // Get offset from top of monitor.

--- a/GlazeWM.Bar/XamlHelper.cs
+++ b/GlazeWM.Bar/XamlHelper.cs
@@ -1,9 +1,20 @@
 using System;
+using System.Linq;
+using GlazeWM.Infrastructure.Utils;
 
 namespace GlazeWM.Bar
 {
   public static class XamlHelper
   {
+    /// <summary>
+    /// Convert size properties from user config (eg. `FontSize`) to be XAML
+    /// compatible.
+    /// </summary>
+    public static string FormatSize(string size)
+    {
+      return $"{UnitsHelper.TrimUnits(size)}";
+    }
+
     /// <summary>
     /// Convert color properties from user config (eg. `Background`) to be XAML
     /// compatible. Colors in the user config are specified in RGBA, whereas XAML expects
@@ -31,9 +42,11 @@ namespace GlazeWM.Bar
     /// <exception cref="ArgumentException"></exception>
     public static string FormatRectShorthand(string shorthand)
     {
-      var shorthandParts = shorthand.Split(" ");
+      var shorthandParts = shorthand.Split(" ")
+        .Select(shorthandPart => UnitsHelper.TrimUnits(shorthandPart))
+        .ToList();
 
-      return shorthandParts.Length switch
+      return shorthandParts.Count switch
       {
         1 => shorthand,
         2 => $"{shorthandParts[1]},{shorthandParts[0]},{shorthandParts[1]},{shorthandParts[0]}",

--- a/GlazeWM.Bootstrapper/sample-config.yaml
+++ b/GlazeWM.Bootstrapper/sample-config.yaml
@@ -3,14 +3,14 @@ gaps:
   outer_gap: 20
 
 bar:
-  height: 30
+  height: "30px"
   position: "top"
   opacity: 1.0
   background: "#20242cc4"
   foreground: "#ffffff"
   font_family: "Segoe UI"
-  font_size: "13"
-  padding: "4 6"
+  font_size: "13px"
+  padding: "4px 6px"
   components_left:
     - type: "workspaces"
       focused_workspace_background: "#ffffff33"
@@ -19,26 +19,26 @@ bar:
   components_right:
     - type: "tiling direction"
       background: "#ffffff33"
-      margin: "0 4"
-      padding: "0 8"
+      margin: "0 4px"
+      padding: "0 8px"
     - type: "binding mode"
       background: "#ffffff33"
-      margin: "0 4 0 0"
-      padding: "0 8"
+      margin: "0 4px 0 0"
+      padding: "0 8px"
     - type: "clock"
       time_formatting: "hh:mm tt  ddd MMM d"
-      margin: "0 0 0 10"
+      margin: "0 0 0 10px"
 
 workspaces:
-  - name: 1
-  - name: 2
-  - name: 3
-  - name: 4
-  - name: 5
-  - name: 6
-  - name: 7
-  - name: 8
-  - name: 9
+  - name: "1"
+  - name: "2"
+  - name: "3"
+  - name: "4"
+  - name: "5"
+  - name: "6"
+  - name: "7"
+  - name: "8"
+  - name: "9"
 
 window_rules:
   # Task Manager requires admin privileges to manage and should be ignored unless running

--- a/GlazeWM.Domain/UserConfigs/BarConfig.cs
+++ b/GlazeWM.Domain/UserConfigs/BarConfig.cs
@@ -4,7 +4,7 @@ namespace GlazeWM.Domain.UserConfigs
 {
   public class BarConfig
   {
-    public uint Height { get; set; } = 30;
+    public string Height { get; set; } = "30px";
 
     public BarPosition Position { get; set; } = BarPosition.Top;
 

--- a/GlazeWM.Domain/Workspaces/Workspace.cs
+++ b/GlazeWM.Domain/Workspaces/Workspace.cs
@@ -3,6 +3,7 @@ using GlazeWM.Domain.Containers;
 using GlazeWM.Domain.Monitors;
 using GlazeWM.Domain.UserConfigs;
 using GlazeWM.Infrastructure;
+using GlazeWM.Infrastructure.Utils;
 
 namespace GlazeWM.Domain.Workspaces
 {
@@ -30,7 +31,7 @@ namespace GlazeWM.Domain.Workspaces
     {
       get
       {
-        var barHeight = _userConfigService.BarConfig.Height;
+        var barHeight = UnitsHelper.TrimUnits(_userConfigService.BarConfig.Height);
         return Convert.ToInt32(barHeight * (Parent as Monitor).ScaleFactor);
       }
     }


### PR DESCRIPTION
* Some properties in the config can be specified as <AMOUNT>px, whereas others have to be specified as <AMOUNT>. Change most properties so that they can either be written as `<AMOUNT>` or `<AMOUNT>px`. `gaps.inner_gap` and `gaps.outer_gap` still need to be defined without `px` affix.

