### PR TITLE
feat: rename bar label properties

### DIFF
--- a/GlazeWM.Bar/Components/BatteryComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/BatteryComponentViewModel.cs
@@ -23,20 +23,20 @@ namespace GlazeWM.Bar.Components
       // display the battery level as a 100% if no dedicated battery is available on the device
       if (ps.BatteryFlag == 128)
       {
-        return _batteryComponentConfig.Draining.Replace("{battery_level}", "100");
+        return _batteryComponentConfig.LabelDraining.Replace("{battery_level}", "100");
       }
 
       if (ps.ACLineStatus == 1)
       {
-        return _batteryComponentConfig.Charging.Replace("{battery_level}", batteryLevel);
+        return _batteryComponentConfig.LabelCharging.Replace("{battery_level}", batteryLevel);
       }
       else if (ps.SystemStatusFlag == 1)
       {
-        return _batteryComponentConfig.PowerSaver.Replace("{battery_level}", batteryLevel);
+        return _batteryComponentConfig.LabelPowerSaver.Replace("{battery_level}", batteryLevel);
       }
       else
       {
-        return _batteryComponentConfig.Draining.Replace("{battery_level}", batteryLevel);
+        return _batteryComponentConfig.LabelDraining.Replace("{battery_level}", batteryLevel);
       }
     }
 

--- a/GlazeWM.Bar/Components/TilingDirectionComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/TilingDirectionComponentViewModel.cs
@@ -19,8 +19,8 @@ namespace GlazeWM.Bar.Components
 
     private TilingDirectionComponentConfig _config => _componentConfig as TilingDirectionComponentConfig;
 
-    private string TextVertical => _config.TextVertical;
-    private string TextHorizontal => _config.TextHorizontal;
+    private string LabelVertical => _config.LabelVertical;
+    private string LabelHorizontal => _config.LabelHorizontal;
 
     /// <summary>
     /// The layout of the currently focused container. Can be null on app startup when
@@ -31,7 +31,7 @@ namespace GlazeWM.Bar.Components
       (_containerService.FocusedContainer.Parent as SplitContainer)?.Layout;
 
     public string TilingDirectionString =>
-      _tilingDirection == Layout.Vertical ? TextVertical : TextHorizontal;
+      _tilingDirection == Layout.Vertical ? LabelVertical : LabelHorizontal;
 
     public TilingDirectionComponentViewModel(
       BarViewModel parentViewModel,

--- a/GlazeWM.Bootstrapper/sample-config.yaml
+++ b/GlazeWM.Bootstrapper/sample-config.yaml
@@ -8,9 +8,6 @@ general:
   cursor_follows_focus: true
 
 bar:
-  offset_x: "0px"
-  offset_y: "0px"
-  border_radius: "0px"
   height: "30px"
   position: "top"
   opacity: 1.0
@@ -19,6 +16,9 @@ bar:
   font_family: "Segoe UI"
   font_size: "13px"
   padding: "4px 6px"
+  offset_x: "0"
+  offset_y: "0"
+  border_radius: "0"
   component_separator:
     label: " | "
   components_left:
@@ -30,8 +30,8 @@ bar:
     - type: "window title"
   components_right:
     - type: "tiling direction"
-      text_horizontal: "⮂"
-      text_vertical: "⮁"
+      label_horizontal: "⮂"
+      label_vertical: "⮁"
       background: "#ffffff33"
       margin: "0 4px"
       padding: "0 8px"
@@ -42,8 +42,6 @@ bar:
     - type: "clock"
       # supported time format specifier:
       # https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings
-      # "w"   Calendarweek (ISO 8601 week) 1..53
-      # "ww"  CalendarWeek (ISO 8601 week) 01..53
       time_formatting: "hh:mm tt  ddd MMM d"
       margin: "0 0 0 10px"
 

--- a/GlazeWM.Domain/UserConfigs/BatteryComponentConfig.cs
+++ b/GlazeWM.Domain/UserConfigs/BatteryComponentConfig.cs
@@ -19,14 +19,14 @@ namespace GlazeWM.Domain.UserConfigs
     /// <summary>
     /// Formatted text to display when the device is draining battery power.
     /// </summary>
-    public string Draining { get; set; } = " {battery_level}% ";
+    public string LabelDraining { get; set; } = "{battery_level}%";
     /// <summary>
     /// Formatted text to display when the device is in power saving mode.
     /// </summary>
-    public string PowerSaver { get; set; } = " {battery_level}% (power saver) ";
+    public string LabelPowerSaver { get; set; } = "{battery_level}% (power saver)";
     /// <summary>
     /// Formatted text to display when the device is connected to power.
     /// </summary>
-    public string Charging { get; set; } = " {battery_level}% (charging) ";
+    public string LabelCharging { get; set; } = "{battery_level}% (charging)";
   }
 }

--- a/GlazeWM.Domain/UserConfigs/TilingDirectionComponentConfig.cs
+++ b/GlazeWM.Domain/UserConfigs/TilingDirectionComponentConfig.cs
@@ -5,11 +5,11 @@ namespace GlazeWM.Domain.UserConfigs
     /// <summary>
     /// Text to display in vertical mode.
     /// </summary>
-    public string TextVertical { get; set; } = "vertical";
+    public string LabelVertical { get; set; } = "vertical";
 
     /// <summary>
     /// Text to display horizontal mode.
     /// </summary>
-    public string TextHorizontal { get; set; } = "horizontal";
+    public string LabelHorizontal { get; set; } = "horizontal";
   }
 }

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Workspaces need to be predefined via the `workspaces` property in the config fil
 workspaces:
   # Uniquely identifies the workspace and is used as the label for the workspace in the bar if
   # `display_name` is not provided.
-  - name: 1
+  - name: "1"
 
     # Optional override for the workspace label in the bar. Does not need to be unique.
     display_name: "Work"
@@ -119,7 +119,7 @@ The appearance of the bar can be changed via the `bar` property in the config fi
 ```yaml
 bar:
   # Height of the bar in pixels.
-  height: 30
+  height: "30px"
 
   # The position of the bar on the screen. Can be either "top" or "bottom".
   position: "top"
@@ -137,7 +137,7 @@ bar:
   font_family: "Segoe UI"
 
   # Default font size. Can be overriden by setting `font_size` in a component's config.
-  font_size: "13"
+  font_size: "13px"
 
   # Default font weight. Typically ranges from 100 to 950, where a higher value is thicker. Can
   # be overriden by setting `font_weight` in a component's config.
@@ -152,16 +152,13 @@ bar:
 
   # Horizontal and vertical spacing between components within the bar and the edges of the bar. See
   # "Shorthand properties" for more info.
-  padding: "1 6 1 6"
+  padding: "4px 6px 4px 6px"
 
-  # Separators between components within the bar. label is used for each section
-  # of the bar unless label_{left,centre,right} are explictly set, in which case
+  # Separator between components within the bar. `label` is used for each section
+  # of the bar unless `label_{left,center,right}` is explictly set, in which case
   # they are preferred over default.
-  component_separators:
+  component_separator:
     label: " | "
-    # label_left: ""
-    # label_center: "" 
-    # label_right: "" 
 
   # Components to display on the left side of the bar.
   components_left:
@@ -181,7 +178,7 @@ The appearance of bar components can also be customized. The following propertie
 type: <COMPONENT_TYPE>
 
 # Horizontal and vertical margins. See "Shorthand properties" for more info.
-margin: "0 10 0 0"
+margin: "0 10px 0 0"
 
 # Horizontal and vertical padding. See "Shorthand properties" for more info.
 padding: "0"
@@ -199,7 +196,7 @@ foreground: "white"
 font_family: "Segoe UI"
 
 # Font size used within the component.
-font_size: "13"
+font_size: "13px"
 
 # Font weight used within the component. Typically ranges from 100 to 950, where a higher value is
 # thicker.
@@ -246,18 +243,20 @@ Additionally supported format specifiers:
 
 The battery component displays the system's battery level in percent.
 There are three labels available that can be customized:
-- `draining`: used when the system is draining battery power(i.e. not charging).
-- `power_saver`: used when the system is on power saving mode.
-- `charging`: used when the system is connected to power.
+
+- `label_draining`: used when the system is draining battery power(i.e. not charging).
+- `label_power_saver`: used when the system is on power saving mode.
+- `label_charging`: used when the system is connected to power.
 
 `{battery_level}` is a variable which is replaced by the actual battery level when the label is displayed.
 
 **Example usage:**
+
 ```yaml
 - type: "battery"
-  draining: "{battery_level}% remaining"
-  power_saver: "{battery_level}% (power saver)"
-  charging: "{battery_level}% (charging)"
+  label_draining: "{battery_level}% remaining"
+  label_power_saver: "{battery_level}% (power saver)"
+  label_charging: "{battery_level}% (charging)"
 ```
 
 ## Window rules


### PR DESCRIPTION
* Improve consistency of label properties in the config. Rename them to be in the format of `label_{condition}`.