### PR TITLE
feat: rename "toggle focus mode" -> "focus mode toggle"

### DIFF
--- a/GlazeWM.Bootstrapper/sample-config.yaml
+++ b/GlazeWM.Bootstrapper/sample-config.yaml
@@ -123,11 +123,11 @@ keybindings:
     binding: "Alt+R"
 
   # Change tiling direction. This determines where new tiling windows will be inserted.
-  - command: "toggle tiling direction"
+  - command: "tiling direction toggle"
     binding: "Alt+V"
 
   # Change focus between floating / tiling windows.
-  - command: "toggle focus mode"
+  - command: "focus mode toggle"
     binding: "Alt+Space"
 
   # Change the focused window to be floating / tiling.

--- a/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
+++ b/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
@@ -131,6 +131,11 @@ namespace GlazeWM.Domain.UserConfigs
         "up" => new FocusInDirectionCommand(Direction.Up),
         "down" => new FocusInDirectionCommand(Direction.Down),
         "workspace" => ParseFocusWorkspaceCommand(commandParts),
+        "mode" => commandParts[2] switch
+        {
+          "toggle" => new ToggleFocusModeCommand(),
+          _ => throw new ArgumentException(null, nameof(commandParts)),
+        },
         _ => throw new ArgumentException(null, nameof(commandParts)),
       };
     }
@@ -233,6 +238,7 @@ namespace GlazeWM.Domain.UserConfigs
         "maximized" => subjectContainer is Window
           ? new ToggleMaximizedCommand(subjectContainer as Window)
           : new NoopCommand(),
+        // TODO: "toggle focus mode" command is deprecated. Remove in next major release.
         "focus" => commandParts[2] switch
         {
           "mode" => new ToggleFocusModeCommand(),


### PR DESCRIPTION
* Rename "toggle focus mode" -> "focus mode toggle".
* Fix incorrect "tiling direction toggle" naming.