### PR TITLE
fix: remove calls to `CenterCursorOnRectCommand`

### DIFF
--- a/GlazeWM.Domain/Containers/CommandHandlers/MoveContainerWithinTreeHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/MoveContainerWithinTreeHandler.cs
@@ -43,9 +43,6 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
           shouldAdjustSize
         );
 
-        // Center cursor in focused window's new location
-        _bus.InvokeAsync(new CenterCursorOnRectCommand(containerToMove.ToRect()));
-
         return CommandResponse.Ok;
       }
 
@@ -89,9 +86,6 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
           originalFocusIndex,
           targetParentAncestor
         );
-
-      // Center cursor in focused window's new location
-      _bus.InvokeAsync(new CenterCursorOnRectCommand(containerToMove.ToRect()));
 
       return CommandResponse.Ok;
     }

--- a/GlazeWM.Domain/Containers/CommandHandlers/SetNativeFocusHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/SetNativeFocusHandler.cs
@@ -45,8 +45,6 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
         _bus.Emit(new FocusChangedEvent(containerToFocus));
       }
 
-      _bus.InvokeAsync(new CenterCursorOnRectCommand(containerToFocus.ToRect()));
-
       return CommandResponse.Ok;
     }
   }


### PR DESCRIPTION
* Fixes crash described in #236.

Closes #236.