### PR TITLE
Observable timers now are disposed on reload

### DIFF
--- a/GlazeWM.Bar/BarService.cs
+++ b/GlazeWM.Bar/BarService.cs
@@ -117,6 +117,8 @@ namespace GlazeWM.Bar
       {
         // Kill the corresponding bar window.
         var barWindow = _activeWindowsByDeviceName.GetValueOrDefault(deviceName);
+
+        barWindow?.BarViewModel?.Dispose();
         barWindow?.Close();
       });
     }

--- a/GlazeWM.Bar/BarViewModel.cs
+++ b/GlazeWM.Bar/BarViewModel.cs
@@ -14,6 +14,7 @@ namespace GlazeWM.Bar
     public Monitor Monitor { get; }
     public Dispatcher Dispatcher { get; }
     public BarConfig BarConfig { get; }
+    public List<IDisposable> Observables { get; } = new();
 
     public BarPosition Position => BarConfig.Position;
     public string Background => XamlHelper.FormatColor(BarConfig.Background);
@@ -65,6 +66,19 @@ namespace GlazeWM.Bar
       InsertComponentSeparator(
         CreateComponentViewModels(BarConfig.ComponentsRight),
           _componentSeparatorRight);
+
+    protected override void Dispose(bool disposing)
+    {
+      if (disposing)
+      {
+        foreach (var observable in Observables)
+        {
+          observable?.Dispose();
+        }
+      }
+
+      base.Dispose(disposing);
+    }
 
     private static List<ComponentViewModel> InsertComponentSeparator(
       List<ComponentViewModel> componentViewModels, TextComponentViewModel componentSeparator

--- a/GlazeWM.Bar/BarViewModel.cs
+++ b/GlazeWM.Bar/BarViewModel.cs
@@ -14,7 +14,7 @@ namespace GlazeWM.Bar
     public Monitor Monitor { get; }
     public Dispatcher Dispatcher { get; }
     public BarConfig BarConfig { get; }
-    public List<IDisposable> Observables { get; } = new();
+    public List<IDisposable> Disposables { get; } = new();
 
     public BarPosition Position => BarConfig.Position;
     public string Background => XamlHelper.FormatColor(BarConfig.Background);
@@ -71,9 +71,9 @@ namespace GlazeWM.Bar
     {
       if (disposing)
       {
-        foreach (var observable in Observables)
+        foreach (var disposable in Disposables)
         {
-          observable?.Dispose();
+          disposable?.Dispose();
         }
       }
 

--- a/GlazeWM.Bar/Common/ViewModelBase.cs
+++ b/GlazeWM.Bar/Common/ViewModelBase.cs
@@ -1,16 +1,25 @@
+using System;
 using System.ComponentModel;
 
 namespace GlazeWM.Bar.Common
 {
-  public class ViewModelBase : INotifyPropertyChanged
+  public class ViewModelBase : INotifyPropertyChanged, IDisposable
   {
     public event PropertyChangedEventHandler PropertyChanged;
+
+    public void Dispose()
+    {
+      Dispose(true);
+      GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+    }
 
     protected void OnPropertyChanged(string propertyName)
     {
       PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
-
-    public virtual void Dispose() { }
   }
 }

--- a/GlazeWM.Bar/Components/BatteryComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/BatteryComponentViewModel.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Globalization;
-using System.Reactive.Linq;
 using GlazeWM.Domain.UserConfigs;
 using GlazeWM.Infrastructure.WindowsApi;
 
@@ -46,8 +45,7 @@ namespace GlazeWM.Bar.Components
     {
       _batteryComponentConfig = config;
 
-      Observable.Interval(TimeSpan.FromSeconds(3))
-        .Subscribe(_ => OnPropertyChanged(nameof(FormattedPowerStatus)));
+      AddUpdateEvent(TimeSpan.FromSeconds(3), () => OnPropertyChanged(nameof(FormattedPowerStatus)));
     }
   }
 }

--- a/GlazeWM.Bar/Components/BatteryComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/BatteryComponentViewModel.cs
@@ -46,9 +46,8 @@ namespace GlazeWM.Bar.Components
     {
       _batteryComponentConfig = config;
 
-      var updateSubscription = Observable
-                               .Interval(TimeSpan.FromSeconds(3))
-                               .Subscribe(_ => OnPropertyChanged(nameof(FormattedPowerStatus)));
+      var updateSubscription = Observable.Interval(TimeSpan.FromSeconds(3))
+        .Subscribe(_ => OnPropertyChanged(nameof(FormattedPowerStatus)));
 
       RegisterDisposables(updateSubscription);
     }

--- a/GlazeWM.Bar/Components/BatteryComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/BatteryComponentViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Reactive.Linq;
 using GlazeWM.Domain.UserConfigs;
 using GlazeWM.Infrastructure.WindowsApi;
 
@@ -45,7 +46,11 @@ namespace GlazeWM.Bar.Components
     {
       _batteryComponentConfig = config;
 
-      AddUpdateEvent(TimeSpan.FromSeconds(3), () => OnPropertyChanged(nameof(FormattedPowerStatus)));
+      var updateSubscription = Observable
+                               .Interval(TimeSpan.FromSeconds(3))
+                               .Subscribe(_ => OnPropertyChanged(nameof(FormattedPowerStatus)));
+
+      RegisterDisposables(updateSubscription);
     }
   }
 }

--- a/GlazeWM.Bar/Components/BindingModeComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/BindingModeComponentViewModel.cs
@@ -31,13 +31,14 @@ namespace GlazeWM.Bar.Components
       BarViewModel parentViewModel,
       BindingModeComponentConfig config) : base(parentViewModel, config)
     {
-      _bus.Events.OfType<BindingModeChangedEvent>().Subscribe(_ =>
+      var bindingModeChangedSubscription = _bus.Events.OfType<BindingModeChangedEvent>().Subscribe(_ =>
         _dispatcher.Invoke(() =>
         {
           OnPropertyChanged(nameof(Visibility));
           OnPropertyChanged(nameof(ActiveBindingMode));
-        })
-      );
+        }));
+
+      RegisterDisposables(bindingModeChangedSubscription);
     }
   }
 }

--- a/GlazeWM.Bar/Components/ClockComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/ClockComponentViewModel.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Globalization;
-using System.Reactive.Linq;
 using System.Text;
 using GlazeWM.Domain.UserConfigs;
 
@@ -64,11 +63,7 @@ namespace GlazeWM.Bar.Components
       BarViewModel parentViewModel,
       ClockComponentConfig config) : base(parentViewModel, config)
     {
-      // Update the displayed time every second.
-      var updateInterval = TimeSpan.FromSeconds(1);
-
-      Observable.Interval(updateInterval)
-        .Subscribe(_ => OnPropertyChanged(nameof(FormattedTime)));
+      AddUpdateEvent(TimeSpan.FromSeconds(1), () => OnPropertyChanged(nameof(FormattedTime)));
     }
   }
 }

--- a/GlazeWM.Bar/Components/ClockComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/ClockComponentViewModel.cs
@@ -64,9 +64,8 @@ namespace GlazeWM.Bar.Components
       BarViewModel parentViewModel,
       ClockComponentConfig config) : base(parentViewModel, config)
     {
-      var updateSubscription = Observable
-                               .Interval(TimeSpan.FromSeconds(1))
-                               .Subscribe(_ => OnPropertyChanged(nameof(FormattedTime)));
+      var updateSubscription = Observable.Interval(TimeSpan.FromSeconds(1))
+        .Subscribe(_ => OnPropertyChanged(nameof(FormattedTime)));
 
       RegisterDisposables(updateSubscription);
     }

--- a/GlazeWM.Bar/Components/ClockComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/ClockComponentViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Reactive.Linq;
 using System.Text;
 using GlazeWM.Domain.UserConfigs;
 
@@ -63,7 +64,11 @@ namespace GlazeWM.Bar.Components
       BarViewModel parentViewModel,
       ClockComponentConfig config) : base(parentViewModel, config)
     {
-      AddUpdateEvent(TimeSpan.FromSeconds(1), () => OnPropertyChanged(nameof(FormattedTime)));
+      var updateSubscription = Observable
+                               .Interval(TimeSpan.FromSeconds(1))
+                               .Subscribe(_ => OnPropertyChanged(nameof(FormattedTime)));
+
+      RegisterDisposables(updateSubscription);
     }
   }
 }

--- a/GlazeWM.Bar/Components/ComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/ComponentViewModel.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Reactive.Linq;
 using GlazeWM.Bar.Common;
 using GlazeWM.Domain.UserConfigs;
 
@@ -23,6 +25,11 @@ namespace GlazeWM.Bar.Components
       XamlHelper.FormatRectShorthand(_componentConfig.BorderWidth);
     public string Padding => XamlHelper.FormatRectShorthand(_componentConfig.Padding);
     public string Margin => XamlHelper.FormatRectShorthand(_componentConfig.Margin);
+
+    protected void AddUpdateEvent(TimeSpan interval, Action action)
+    {
+      _parentViewModel.Observables.Add(Observable.Interval(interval).Subscribe(_ => action()));
+    }
 
     protected ComponentViewModel(BarViewModel parentViewModel, BarComponentConfig baseConfig)
     {

--- a/GlazeWM.Bar/Components/ComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/ComponentViewModel.cs
@@ -26,9 +26,9 @@ namespace GlazeWM.Bar.Components
     public string Padding => XamlHelper.FormatRectShorthand(_componentConfig.Padding);
     public string Margin => XamlHelper.FormatRectShorthand(_componentConfig.Margin);
 
-    protected void AddUpdateEvent(TimeSpan interval, Action action)
+    protected void RegisterDisposables(params IDisposable[] disposables)
     {
-      _parentViewModel.Observables.Add(Observable.Interval(interval).Subscribe(_ => action()));
+      _parentViewModel.Disposables.AddRange(disposables);
     }
 
     protected ComponentViewModel(BarViewModel parentViewModel, BarComponentConfig baseConfig)

--- a/GlazeWM.Bar/Components/NetworkComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/NetworkComponentViewModel.cs
@@ -54,9 +54,8 @@ namespace GlazeWM.Bar.Components
       BarViewModel parentViewModel,
       NetworkComponentConfig config) : base(parentViewModel, config)
     {
-      var updateSubscription = Observable
-                               .Interval(TimeSpan.FromSeconds(10))
-                               .Subscribe(_ => OnPropertyChanged(nameof(Text)));
+      var updateSubscription = Observable.Interval(TimeSpan.FromSeconds(10))
+        .Subscribe(_ => OnPropertyChanged(nameof(Text)));
 
       RegisterDisposables(updateSubscription);
 

--- a/GlazeWM.Bar/Components/NetworkComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/NetworkComponentViewModel.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Net.NetworkInformation;
-using System.Reactive.Linq;
 using GlazeWM.Domain.UserConfigs;
 using GlazeWM.Infrastructure.WindowsApi;
 using static Vanara.PInvoke.IpHlpApi;
@@ -54,8 +53,8 @@ namespace GlazeWM.Bar.Components
       BarViewModel parentViewModel,
       NetworkComponentConfig config) : base(parentViewModel, config)
     {
-      Observable.Interval(TimeSpan.FromSeconds(10))
-        .Subscribe(_ => OnPropertyChanged(nameof(Text)));
+      AddUpdateEvent(TimeSpan.FromSeconds(10), () => OnPropertyChanged(nameof(Text)));
+
       NetworkChange.NetworkAddressChanged += new NetworkAddressChangedEventHandler((s, e) => OnPropertyChanged(nameof(Text)));
     }
   }

--- a/GlazeWM.Bar/Components/NetworkComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/NetworkComponentViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net.NetworkInformation;
+using System.Reactive.Linq;
 using GlazeWM.Domain.UserConfigs;
 using GlazeWM.Infrastructure.WindowsApi;
 using static Vanara.PInvoke.IpHlpApi;
@@ -53,7 +54,11 @@ namespace GlazeWM.Bar.Components
       BarViewModel parentViewModel,
       NetworkComponentConfig config) : base(parentViewModel, config)
     {
-      AddUpdateEvent(TimeSpan.FromSeconds(10), () => OnPropertyChanged(nameof(Text)));
+      var updateSubscription = Observable
+                               .Interval(TimeSpan.FromSeconds(10))
+                               .Subscribe(_ => OnPropertyChanged(nameof(Text)));
+
+      RegisterDisposables(updateSubscription);
 
       NetworkChange.NetworkAddressChanged += new NetworkAddressChangedEventHandler((s, e) => OnPropertyChanged(nameof(Text)));
     }

--- a/GlazeWM.Bar/Components/NotifyIconViewModel.cs
+++ b/GlazeWM.Bar/Components/NotifyIconViewModel.cs
@@ -10,7 +10,9 @@ namespace GlazeWM.Bar.Components
   public class NotifyIconViewModel : ViewModelBase
   {
     public ManagedShell.WindowsTray.NotifyIcon TrayIcon { get; set; }
-    // Hide native tray icons
+    /// <summary>
+    /// Hide native tray icons
+    /// </summary>
     public bool IsVisible => !TrayIcon.Path.Contains("\\Windows\\explorer.exe");
     public ICommand OnMouseUpCommand =>
       new RelayCommand<MouseButtonEventArgs>(OnMouseUp);

--- a/GlazeWM.Bar/Components/TilingDirectionComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/TilingDirectionComponentViewModel.cs
@@ -37,11 +37,11 @@ namespace GlazeWM.Bar.Components
       BarViewModel parentViewModel,
       TilingDirectionComponentConfig config) : base(parentViewModel, config)
     {
-      _bus.Events.Where(
-        (@event) => @event is LayoutChangedEvent or FocusChangedEvent
-      ).Subscribe((_) =>
-        _dispatcher.Invoke(() => OnPropertyChanged(nameof(TilingDirectionString)))
-      );
+      var layoutChangedSubscription = _bus.Events.Where(
+        @event => @event is LayoutChangedEvent or FocusChangedEvent).Subscribe(_ =>
+        _dispatcher.Invoke(() => OnPropertyChanged(nameof(TilingDirectionString))));
+
+      RegisterDisposables(layoutChangedSubscription);
     }
   }
 }

--- a/GlazeWM.Bar/Components/WindowTitleComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/WindowTitleComponentViewModel.cs
@@ -30,11 +30,13 @@ namespace GlazeWM.Bar.Components
       BarViewModel parentViewModel,
       WindowTitleComponentConfig config) : base(parentViewModel, config)
     {
-      _bus.Events.OfType<WindowFocusedEvent>()
+      var windowFocusedSubscription = _bus.Events.OfType<WindowFocusedEvent>()
         .Subscribe((@event) => UpdateTitle(@event.WindowHandle));
 
-      _bus.Events.OfType<WindowTitleChangedEvent>()
+      var windowTitleChangedSubscription = _bus.Events.OfType<WindowTitleChangedEvent>()
         .Subscribe((@event) => UpdateTitle(@event.WindowHandle));
+
+      RegisterDisposables(windowFocusedSubscription, windowTitleChangedSubscription);
     }
 
     private void UpdateTitle(IntPtr windowHandle)

--- a/GlazeWM.Bar/Components/WorkspacesComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/WorkspacesComponentViewModel.cs
@@ -79,11 +79,11 @@ namespace GlazeWM.Bar.Components
           or WorkspaceDeactivatedEvent
           or FocusChangedEvent
       );
-
       // Refresh contents of workspaces collection.
-      workspacesChangedEvent.Subscribe(_ =>
-        _dispatcher.Invoke(() => OnPropertyChanged(nameof(Workspaces)))
-      );
+      var workspaceChangedEventSubscription = workspacesChangedEvent.Subscribe(_ =>
+        _dispatcher.Invoke(() => OnPropertyChanged(nameof(Workspaces))));
+
+      RegisterDisposables(workspaceChangedEventSubscription);
     }
 
     public void FocusWorkspace(string workspaceName)

--- a/GlazeWM.Bar/MainWindow.xaml.cs
+++ b/GlazeWM.Bar/MainWindow.xaml.cs
@@ -19,13 +19,14 @@ namespace GlazeWM.Bar
   public partial class MainWindow : Window
   {
     private readonly Bus _bus = ServiceLocator.GetRequiredService<Bus>();
-    private BarViewModel _barViewModel { get; }
-    private Dispatcher _dispatcher => _barViewModel.Dispatcher;
-    private Monitor _monitor => _barViewModel.Monitor;
+    private Dispatcher _dispatcher => BarViewModel.Dispatcher;
+    private Monitor _monitor => BarViewModel.Monitor;
+
+    public BarViewModel BarViewModel { get; }
 
     public MainWindow(BarViewModel barViewModel)
     {
-      _barViewModel = barViewModel;
+      BarViewModel = barViewModel;
       DataContext = barViewModel;
 
       InitializeComponent();
@@ -62,16 +63,16 @@ namespace GlazeWM.Bar
     private void PositionWindow(IntPtr windowHandle)
     {
       // Since window size is set manually, need to scale up height to make window DPI responsive.
-      var barHeight = UnitsHelper.TrimUnits(_barViewModel.BarConfig.Height);
+      var barHeight = UnitsHelper.TrimUnits(BarViewModel.BarConfig.Height);
       var scaledBarHeight = Convert.ToInt32(barHeight * _monitor.ScaleFactor);
 
       // Get offset from top of monitor.
-      var barOffsetY = _barViewModel.BarConfig.Position == BarPosition.Bottom
+      var barOffsetY = BarViewModel.BarConfig.Position == BarPosition.Bottom
         ? _monitor.Height - scaledBarHeight
         : 0;
 
-      var floatBarOffsetX = UnitsHelper.TrimUnits(_barViewModel.BarConfig.OffsetX);
-      var floatBarOffsetY = UnitsHelper.TrimUnits(_barViewModel.BarConfig.OffsetY);
+      var floatBarOffsetX = UnitsHelper.TrimUnits(BarViewModel.BarConfig.OffsetX);
+      var floatBarOffsetY = UnitsHelper.TrimUnits(BarViewModel.BarConfig.OffsetY);
 
       // The first move puts it on the correct monitor, which triggers WM_DPICHANGED.
       MoveWindow(


### PR DESCRIPTION
![NVIDIA_Share_ntsq83NYK7](https://user-images.githubusercontent.com/84819317/220209615-0e854372-3e25-4000-954e-f208cb67265d.gif)
When the bar was being reloaded it wasn't disposing of observables in the component view models now you can use the method:
AddUpdateEvent(TimeSpan interval, Action action) to register an observable timer and they will be properly disposed of.