### PR TITLE
feat: add border radius option for bar components

### DIFF
--- a/GlazeWM.Bar/Components/ComponentPortal.xaml
+++ b/GlazeWM.Bar/Components/ComponentPortal.xaml
@@ -8,40 +8,40 @@
   mc:Ignorable="d">
   <Grid
     Visibility="{Binding Visibility}"
-    Margin="{Binding Margin}"
-    Background="{Binding Background}">
+    Margin="{Binding Margin}">
     <Border
+      CornerRadius="{Binding BorderRadius}"
       BorderThickness="{Binding BorderWidth}"
       BorderBrush="{Binding BorderColor}">
-      <Grid Margin="{Binding Padding}">
+      <Grid>
         <ContentPresenter Content="{Binding .}">
           <ContentPresenter.Resources>
             <DataTemplate DataType="{x:Type components:BatteryComponentViewModel}">
-              <components:BatteryComponent />
+              <components:BatteryComponent Padding="{Binding Padding}" Background="{Binding Background}" />
             </DataTemplate>
             <DataTemplate DataType="{x:Type components:BindingModeComponentViewModel}">
-              <components:BindingModeComponent />
+              <components:BindingModeComponent Padding="{Binding Padding}" Background="{Binding Background}" />
             </DataTemplate>
             <DataTemplate DataType="{x:Type components:ClockComponentViewModel}">
-              <components:ClockComponent />
+              <components:ClockComponent Padding="{Binding Padding}" Background="{Binding Background}" />
             </DataTemplate>
             <DataTemplate DataType="{x:Type components:TextComponentViewModel}">
-              <components:TextComponent />
+              <components:TextComponent Padding="{Binding Padding}" Background="{Binding Background}" />
             </DataTemplate>
             <DataTemplate DataType="{x:Type components:NetworkComponentViewModel}">
-              <components:NetworkComponent />
+              <components:NetworkComponent Padding="{Binding Padding}" Background="{Binding Background}" />
             </DataTemplate>
             <DataTemplate DataType="{x:Type components:WindowTitleComponentViewModel}">
-              <components:WindowTitleComponent />
+              <components:WindowTitleComponent Padding="{Binding Padding}" Background="{Binding Background}" />
             </DataTemplate>
             <DataTemplate DataType="{x:Type components:SystemTrayComponentViewModel}">
-              <components:SystemTrayComponent />
+              <components:SystemTrayComponent Padding="{Binding Padding}" Background="{Binding Background}" />
             </DataTemplate>
             <DataTemplate DataType="{x:Type components:TilingDirectionComponentViewModel}">
-              <components:TilingDirectionComponent />
+              <components:TilingDirectionComponent Padding="{Binding Padding}" Background="{Binding Background}" />
             </DataTemplate>
             <DataTemplate DataType="{x:Type components:WorkspacesComponentViewModel}">
-              <components:WorkspacesComponent />
+              <components:WorkspacesComponent Padding="{Binding Padding}" Background="{Binding Background}" />
             </DataTemplate>
           </ContentPresenter.Resources>
         </ContentPresenter>

--- a/GlazeWM.Bar/Components/ComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/ComponentViewModel.cs
@@ -21,6 +21,7 @@ namespace GlazeWM.Bar.Components
     public string BorderColor => XamlHelper.FormatColor(_componentConfig.BorderColor);
     public string BorderWidth =>
       XamlHelper.FormatRectShorthand(_componentConfig.BorderWidth);
+    public string BorderRadius => XamlHelper.FormatSize(_componentConfig.BorderRadius);
     public string Padding => XamlHelper.FormatRectShorthand(_componentConfig.Padding);
     public string Margin => XamlHelper.FormatRectShorthand(_componentConfig.Margin);
 

--- a/GlazeWM.Bar/MainWindow.xaml
+++ b/GlazeWM.Bar/MainWindow.xaml
@@ -13,7 +13,7 @@
   ShowInTaskbar="False"
   Width="800"
   Height="50"
-  Background="{Binding Background}"
+  Background="Transparent"
   FontFamily="{Binding FontFamily}"
   FontWeight="{Binding FontWeight}"
   FontSize="{Binding FontSize}"
@@ -23,7 +23,8 @@
   <Border
     CornerRadius="{Binding BorderRadius}"
     BorderThickness="{Binding BorderWidth}"
-    BorderBrush="{Binding BorderColor}">
+    BorderBrush="{Binding BorderColor}"
+    Background="{Binding Background}">
     <Grid Margin="{Binding Padding}">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="*" />

--- a/GlazeWM.Domain/UserConfigs/BarComponentConfig.cs
+++ b/GlazeWM.Domain/UserConfigs/BarComponentConfig.cs
@@ -38,6 +38,11 @@ namespace GlazeWM.Domain.UserConfigs
     public string BorderColor { get; set; } = "blue";
 
     /// <summary>
+    /// Radius of the border in pixels.
+    /// </summary>
+    public string BorderRadius { get; set; } = "0px";
+
+    /// <summary>
     /// Width of the border in pixels. To set a different border width for each side, specify four
     /// values (eg. "5 0 5 0"). The borders widths apply to the top, right, bottom, and left in that
     /// order.


### PR DESCRIPTION
Hi,
There are two parts this pull request: 
- rounded corners for bar components
- a fix to the bar component border

If you want me to split these to 2 different PRs let me know.

The changes to the bar fix the background overflowing the border. Here is the before and after: 
![mmJ0rJKvfj](https://user-images.githubusercontent.com/57330540/220735572-337a60ed-2378-495e-9043-11fad1a2d444.png)
![di4hERa0qu](https://user-images.githubusercontent.com/57330540/220735676-3fdded49-52c6-438a-8f7d-d0e62ac95da3.png)

I have also added the possibility of adding rounded corners to bar components. With this I have a small problem. For some components there is a 1 pixel line that is transparent for some reason: 

![bwNoJqRWup](https://user-images.githubusercontent.com/57330540/220736390-3590e184-6d60-44b3-b399-d90dd96b5bde.png)

If you have any ideas how to fix that or any other recommendations let me know. 

Joonatan