### PR TITLE
fix: exception when creating `sample-config.yaml`

### DIFF
--- a/GlazeWM.Domain/UserConfigs/CommandHandlers/EvaluateUserConfigHandler.cs
+++ b/GlazeWM.Domain/UserConfigs/CommandHandlers/EvaluateUserConfigHandler.cs
@@ -82,7 +82,7 @@ namespace GlazeWM.Domain.UserConfigs.CommandHandlers
         throw new FatalUserException("Cannot start the app without a configuration file.");
 
       var assembly = Assembly.GetEntryAssembly();
-      const string sampleConfigResourceName = "GlazeWM.Bootstrapper.sample-config.yaml";
+      const string sampleConfigResourceName = "GlazeWM.Bootstrapper.Resources.sample-config.yaml";
 
       // Create containing directory. Needs to be created before writing to the file.
       Directory.CreateDirectory(Path.GetDirectoryName(userConfigPath));


### PR DESCRIPTION
On first launch, after answering Yes to creating a sample file, the following exception was being thrown:

> System.NullReferenceException: Object reference not set to an instance of an object.
>    at GlazeWM.Domain.UserConfigs.CommandHandlers.EvaluateUserConfigHandler.Handle(EvaluateUserConfigCommand command) in C:\source\github\GlazeWM\GlazeWM.Domain\UserConfigs\CommandHandlers\EvaluateUserConfigHandler.cs:line 57
>    at GlazeWM.Infrastructure.Bussing.Bus.Invoke[T](T command) in C:\source\github\GlazeWM\GlazeWM.Infrastructure\Bussing\Bus.cs:line 41
>    at GlazeWM.Domain.Common.CommandHandlers.PopulateInitialStateHandler.Handle(PopulateInitialStateCommand command) in C:\source\github\GlazeWM\GlazeWM.Domain\Common\CommandHandlers\PopulateInitialStateHandler.cs:line 38
>    at GlazeWM.Infrastructure.Bussing.Bus.Invoke[T](T command) in C:\source\github\GlazeWM\GlazeWM.Infrastructure\Bussing\Bus.cs:line 41
>    at GlazeWM.Bootstrapper.Startup.Run() in C:\source\github\GlazeWM\GlazeWM.Bootstrapper\Startup.cs:line 53
> Command history: HandleFatalExceptionCommand, EvaluateUserConfigCommand, PopulateInitialStateCommand State dump: {"X":0,"Y":0,"Width":0,"Height":0,"__type":"RootContainer","FocusIndex":0,"Children":[]}


The config.yaml in ~/.glaze-wm/ had a length of 0.

Adjusted the namespace of the embedded resource for sampleConfigResourceName from

`GlazeWM.Bootstrapper.sample-config.yaml`

to

`GlazeWM.Bootstrapper.Resources.sample-config.yaml`