### PR TITLE
feat: add option to toggle workspace on refocus

### DIFF
--- a/GlazeWM.Bootstrapper/Resources/sample-config.yaml
+++ b/GlazeWM.Bootstrapper/Resources/sample-config.yaml
@@ -7,7 +7,7 @@ general:
   show_floating_on_top: false
   floating_window_move_amount: "5%"
   # When enabled, switching to the current workspace activates the previously focused workspace
-  workspace_auto_back_and_forth: false
+  toggle_workspace_on_refocus: false
 
 bar:
   height: "30px"

--- a/GlazeWM.Bootstrapper/Resources/sample-config.yaml
+++ b/GlazeWM.Bootstrapper/Resources/sample-config.yaml
@@ -6,6 +6,8 @@ general:
   # Whether to show floating windows as always on top.
   show_floating_on_top: false
   floating_window_move_amount: "5%"
+  # When enabled, switching to the current workspace activates the previously focused workspace
+  workspace_auto_back_and_forth: false
 
 bar:
   height: "30px"

--- a/GlazeWM.Domain/UserConfigs/GeneralConfig.cs
+++ b/GlazeWM.Domain/UserConfigs/GeneralConfig.cs
@@ -18,6 +18,6 @@ namespace GlazeWM.Domain.UserConfigs
     /// <summary>
     /// If activated, by switching to the current workspace the previous focused workspace is activated.
     /// </summary>
-    public bool WorkspaceAutoBackAndForth { get; set; }
+    public bool ToggleWorkspaceOnRefocus { get; set; }
   }
 }

--- a/GlazeWM.Domain/UserConfigs/GeneralConfig.cs
+++ b/GlazeWM.Domain/UserConfigs/GeneralConfig.cs
@@ -15,5 +15,9 @@ namespace GlazeWM.Domain.UserConfigs
     /// Amount by which to move floating windows
     /// </summary>
     public string FloatingWindowMoveAmount { get; set; } = "5%";
+    /// <summary>
+    /// If activated, by switching to the current workspace the previous focused workspace is activated.
+    /// </summary>
+    public bool WorkspaceAutoBackAndForth { get; set; }
   }
 }

--- a/GlazeWM.Domain/Workspaces/CommandHandlers/FocusWorkspaceHandler.cs
+++ b/GlazeWM.Domain/Workspaces/CommandHandlers/FocusWorkspaceHandler.cs
@@ -45,7 +45,7 @@ namespace GlazeWM.Domain.Workspaces.CommandHandlers
 
       if (focusedWorkspace == workspaceToFocus)
       {
-        if (!_userConfigService.GeneralConfig.WorkspaceAutoBackAndForth)
+        if (!_userConfigService.GeneralConfig.ToggleWorkspaceOnRefocus)
           return CommandResponse.Ok;
         workspaceToFocus = _workspaceService.MostRecentWorkspace;
       }

--- a/GlazeWM.Domain/Workspaces/CommandHandlers/FocusWorkspaceHandler.cs
+++ b/GlazeWM.Domain/Workspaces/CommandHandlers/FocusWorkspaceHandler.cs
@@ -44,7 +44,11 @@ namespace GlazeWM.Domain.Workspaces.CommandHandlers
       var displayedWorkspace = (workspaceToFocus.Parent as Monitor).DisplayedWorkspace;
 
       if (focusedWorkspace == workspaceToFocus)
-        return CommandResponse.Ok;
+      {
+        if (!_userConfigService.GeneralConfig.WorkspaceAutoBackAndForth)
+          return CommandResponse.Ok;
+        workspaceToFocus = _workspaceService.MostRecentWorkspace;
+      }
 
       // Save currently focused workspace as recent for command "recent"
       _workspaceService.MostRecentWorkspace = focusedWorkspace;

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ general:
   show_floating_on_top: false
   floating_window_move_amount: "5%"
   # When enabled, switching to the current workspace activates the previously focused workspace
-  workspace_auto_back_and_forth: false
+  toggle_workspace_on_refocus: false
 ```
 
 ## Keybindings

--- a/README.md
+++ b/README.md
@@ -62,8 +62,18 @@ The configuration file for GlazeWM can be found at `C:\Users\<YOUR_USER>\.glaze-
 
 To use a different config file location, you can launch the GlazeWM executable with the CLI argument `--config="..."`, like so:
 
-```
+```console
 ./GlazeWM.exe --config="C:\<PATH_TO_CONFIG>\config.yaml"
+```
+
+## General
+
+```yaml
+general:
+  show_floating_on_top: false
+  floating_window_move_amount: "5%"
+  # When enabled, switching to the current workspace activates the previously focused workspace
+  workspace_auto_back_and_forth: false
 ```
 
 ## Keybindings


### PR DESCRIPTION
Added a configuration option to enable automatic back-and-forth (as in [i3wm](https://i3wm.org/docs/userguide.html#workspace_auto_back_and_forth))

With this configuration enabled the previous workspace will be focused when switching to the current workspace.

See also #151