### PR TITLE
add exec_a run process as user and yaml variables support

### DIFF
--- a/GlazeWM.Domain/Common/CommandHandlers/ExecProcessHandler.cs
+++ b/GlazeWM.Domain/Common/CommandHandlers/ExecProcessHandler.cs
@@ -12,6 +12,10 @@ namespace GlazeWM.Domain.Common.CommandHandlers
     {
       var processName = command.ProcessName;
       var args = command.Args;
+      var processUserName = command.ProcessUserName;
+      var processPassword = command.ProcessPassword;
+      var useShellExecute = processUserName.Length == 0 || processPassword.Length == 0;
+      var verb = useShellExecute ? "" : "RunAsUser";
 
       try
       {
@@ -21,10 +25,14 @@ namespace GlazeWM.Domain.Common.CommandHandlers
           // Expand env variables in the process name (eg. "%ProgramFiles%").
           FileName = Environment.ExpandEnvironmentVariables(processName),
           Arguments = string.Join(" ", args),
-          UseShellExecute = true,
+          UseShellExecute = useShellExecute,
           // Set user profile directory as the working dir. This affects the starting directory
           // of terminal processes (eg. CMD, Git bash, etc).
           WorkingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+          // Run As User
+          Verb = verb,
+          UserName = processUserName,
+          PasswordInClearText = processPassword,
         };
         process.Start();
       }

--- a/GlazeWM.Domain/Common/Commands/ExecProcessCommand.cs
+++ b/GlazeWM.Domain/Common/Commands/ExecProcessCommand.cs
@@ -6,12 +6,16 @@ namespace GlazeWM.Domain.Common.Commands
   public class ExecProcessCommand : Command
   {
     public string ProcessName { get; }
+    public string ProcessUserName { get; }
+    public string ProcessPassword { get; }
     public List<string> Args { get; }
 
-    public ExecProcessCommand(string processName, List<string> args)
+    public ExecProcessCommand(string processName, List<string> args, string processUserName = "", string processPassword = "")
     {
       ProcessName = processName;
       Args = args;
+      ProcessUserName = processUserName;
+      ProcessPassword = processPassword;
     }
   }
 }

--- a/GlazeWM.Domain/UserConfigs/CommandHandlers/EvaluateUserConfigHandler.cs
+++ b/GlazeWM.Domain/UserConfigs/CommandHandlers/EvaluateUserConfigHandler.cs
@@ -102,6 +102,16 @@ namespace GlazeWM.Domain.UserConfigs.CommandHandlers
         var userConfigLines = File.ReadAllLines(userConfigPath);
         var input = string.Join(Environment.NewLine, userConfigLines);
 
+        var globalVariables = _yamlService.Deserialize<UserConfigVariables>(
+          input,
+          new List<JsonConverter>() { new BarComponentConfigConverter() }
+        );
+
+        foreach (var item in globalVariables.Globals)
+        {
+          input = input.Replace($"{{{{{item.Name}}}}}", item.Value);
+        }
+
         return _yamlService.Deserialize<UserConfig>(
           input,
           new List<JsonConverter>() { new BarComponentConfigConverter() }

--- a/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
+++ b/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
@@ -85,6 +85,12 @@ namespace GlazeWM.Domain.UserConfigs
           ? new CloseWindowCommand(subjectContainer as Window)
           : new NoopCommand(),
         "reload" => ParseReloadCommand(commandParts),
+        "exec_a" => new ExecProcessCommand(
+          ExtractProcessAName(string.Join(" ", commandParts[1..])),
+          ExtractProcessAArgs(string.Join(" ", commandParts[1..])),
+          ExtractProcessAUserName(string.Join(" ", commandParts[1..])),
+          ExtractProcessAPassword(string.Join(" ", commandParts[1..]))
+        ),
         "exec" => new ExecProcessCommand(
           ExtractProcessName(string.Join(" ", commandParts[1..])),
           ExtractProcessArgs(string.Join(" ", commandParts[1..]))
@@ -324,6 +330,56 @@ namespace GlazeWM.Domain.UserConfigs
       var args = hasSingleQuotes
         ? processNameAndArgs.Split("'")[2..]
         : processNameAndArgs.Split(" ")[1..];
+
+      return args.Where(arg => !string.IsNullOrWhiteSpace(arg)).ToList();
+    }
+
+    public static string ExtractProcessAUserName(string processNameAndArgs)
+    {
+      var hasSingleQuotes = processNameAndArgs.StartsWith(
+        "'",
+        StringComparison.InvariantCulture
+      );
+
+      return hasSingleQuotes
+        ? processNameAndArgs.Split("'")[1]
+        : processNameAndArgs.Split(" ")[0];
+    }
+
+    public static string ExtractProcessAPassword(string processNameAndArgs)
+    {
+      var hasSingleQuotes = processNameAndArgs.StartsWith(
+        "'",
+        StringComparison.InvariantCulture
+      );
+
+      return hasSingleQuotes
+        ? processNameAndArgs.Split("'")[2]
+        : processNameAndArgs.Split(" ")[1];
+    }
+
+    public static string ExtractProcessAName(string processNameAndArgs)
+    {
+      var hasSingleQuotes = processNameAndArgs.StartsWith(
+        "'",
+        StringComparison.InvariantCulture
+      );
+
+      return hasSingleQuotes
+        ? processNameAndArgs.Split("'")[3]
+        : processNameAndArgs.Split(" ")[2];
+    }
+
+    public static List<string> ExtractProcessAArgs(string processNameAndArgs)
+    {
+      var hasSingleQuotes = processNameAndArgs.StartsWith(
+        "'",
+        StringComparison.InvariantCulture
+      );
+
+      var args = hasSingleQuotes
+        ? processNameAndArgs.Split("'")[4..]
+        : processNameAndArgs.Split(" ")[3..];
 
       return args.Where(arg => !string.IsNullOrWhiteSpace(arg)).ToList();
     }

--- a/GlazeWM.Domain/UserConfigs/GlobalVariablesConfig.cs
+++ b/GlazeWM.Domain/UserConfigs/GlobalVariablesConfig.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace GlazeWM.Domain.UserConfigs
+{
+  public class GlobalVariablesConfig
+  {
+    [Required]
+    public string Name { get; set; }
+
+    [Required]
+    public string Value { get; set; }
+  }
+}

--- a/GlazeWM.Domain/UserConfigs/UserConfigVariables.cs
+++ b/GlazeWM.Domain/UserConfigs/UserConfigVariables.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace GlazeWM.Domain.UserConfigs
+{
+  public class UserConfigVariables
+  {
+    public List<GlobalVariablesConfig> Globals { get; set; } = new();
+  }
+}

--- a/README.md
+++ b/README.md
@@ -320,6 +320,18 @@ window_rules:
     match_process_name: "notepad"
 ```
 
+## Yaml Global Variables
+```yaml
+globals:
+  - name: "username"
+    value: "user_1"
+  - name: "password"
+    value: "12345"
+
+command: "exec_a {{username}} {{password}} powershell"
+
+```
+
 # Available commands
 
 - layout \<vertical | horizontal>

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The appearance of the bar can be changed via the `bar` property in the config fi
 bar:
   # The option to enable/disable the bar.
   enabled: true
-  
+
   # Height of the bar in pixels.
   height: "30px"
 
@@ -339,6 +339,7 @@ window_rules:
 - reload config
 - close
 - exec \<process name | path to executable> (eg. `exec chrome` or `exec 'C:/Program Files/Google/Chrome/Application/chrome'`)
+- exec_a \<username> \<password> \<process name | path to executable> (eg. `exec_a user_1 12345 powershell`)
 - ignore
 
 # Known issues


### PR DESCRIPTION
In case that you have GlazeWM run as admin and you does not want to run process such as powershell as admin
and yaml variable support

```yaml
globals:
- name: "username"
  value: "user_1"
- name: "password"
  value: "12345"
- name: "inner_gap"
  value: 20

gaps:
  inner_gap: "{{inner_gap}}"

command: "exec_a {{username}} {{password}} powershell"
```