### PR TITLE
feat: add shorthand syntax to outer gaps

### DIFF
--- a/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
+++ b/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
@@ -328,7 +328,7 @@ namespace GlazeWM.Domain.UserConfigs
       return args.Where(arg => !string.IsNullOrWhiteSpace(arg)).ToList();
     }
 
-    private static RectDelta ShorthandToRectDelta(string shorthand)
+    public static RectDelta ShorthandToRectDelta(string shorthand)
     {
       var shorthandParts = shorthand.Split(" ")
         .Select(shorthandPart => UnitsHelper.TrimUnits(shorthandPart))

--- a/GlazeWM.Domain/UserConfigs/GapsConfig.cs
+++ b/GlazeWM.Domain/UserConfigs/GapsConfig.cs
@@ -3,6 +3,6 @@ namespace GlazeWM.Domain.UserConfigs
   public class GapsConfig
   {
     public int InnerGap { get; set; } = 20;
-    public int OuterGap { get; set; } = 20;
+    public string OuterGap { get; set; } = "20px";
   }
 }

--- a/GlazeWM.Domain/Workspaces/Workspace.cs
+++ b/GlazeWM.Domain/Workspaces/Workspace.cs
@@ -5,6 +5,7 @@ using GlazeWM.Domain.Monitors;
 using GlazeWM.Domain.UserConfigs;
 using GlazeWM.Infrastructure;
 using GlazeWM.Infrastructure.Utils;
+using GlazeWM.Infrastructure.WindowsApi;
 
 namespace GlazeWM.Domain.Workspaces
 {
@@ -46,7 +47,7 @@ namespace GlazeWM.Domain.Workspaces
       }
     }
 
-    private int _outerGap => _userConfigService.GapsConfig.OuterGap;
+    private RectDelta _outerGaps => CommandParsingService.ShorthandToRectDelta(_userConfigService.GapsConfig.OuterGap);
 
     private BarConfig barForMonitor => _userConfigService.GetBarConfigForMonitor(Parent as Monitor);
     private int floatBarOffsetY => UnitsHelper.TrimUnits(barForMonitor.OffsetY);
@@ -57,25 +58,25 @@ namespace GlazeWM.Domain.Workspaces
       {
         if (!_userConfigService.GetBarConfigForMonitor(Parent as Monitor).Enabled)
         {
-          return Parent.Height - (_outerGap * 2);
+          return Parent.Height - _outerGaps.Top - _outerGaps.Bottom;
         }
 
-        return Parent.Height - (_outerGap * 2) - floatBarOffsetY - _logicalBarHeight;
+        return Parent.Height - _outerGaps.Top - _outerGaps.Bottom - floatBarOffsetY - _logicalBarHeight;
       }
     }
 
-    public override int Width => Parent.Width - (_outerGap * 2);
-    public override int X => Parent.X + _outerGap;
+    public override int Width => Parent.Width - _outerGaps.Left - _outerGaps.Right;
+    public override int X => Parent.X + _outerGaps.Left;
     public override int Y
     {
       get
       {
         if (!_userConfigService.GetBarConfigForMonitor(Parent as Monitor).Enabled)
         {
-          return Parent.Y + _outerGap;
+          return Parent.Y + _outerGaps.Top;
         }
 
-        return Parent.Y + _outerGap + _yOffset + floatBarOffsetY;
+        return Parent.Y + _outerGaps.Top + _yOffset + floatBarOffsetY;
       }
     }
 

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ gaps:
   # Gap between adjacent windows.
   inner_gap: 20
 
-  # Gap between windows and the screen edge.
-  outer_gap: 20
+  # Gap between windows and the screen edge. See "Shorthand properties" for more info.
+  outer_gap: "20px 0 20px 0"
 ```
 
 ## Workspaces configuration


### PR DESCRIPTION
* Added support for specifying individual outer gaps (top, right, bottom, left)
* Also tested that this change is backwards compatible with existing config (i.e. `outer_gap: 20` still works)

closes: #276 