### PR TITLE
feat: parse bar component labels

### DIFF
--- a/GlazeWM.Bar/Components/BatteryComponent.xaml
+++ b/GlazeWM.Bar/Components/BatteryComponent.xaml
@@ -6,11 +6,5 @@
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
   xmlns:components="clr-namespace:GlazeWM.Bar.Components"
   mc:Ignorable="d">
-  <components:Label
-    VerticalAlignment="Center"
-    Foreground="{Binding Foreground}"
-    FontFamily="{Binding FontFamily}"
-    FontWeight="{Binding FontWeight}"
-    FontSize="{Binding FontSize}"
-    Text="{Binding FormattedPowerStatus}" />
+  <components:LabelComponent DataContext="{Binding Label}" />
 </UserControl>

--- a/GlazeWM.Bar/Components/BatteryComponent.xaml
+++ b/GlazeWM.Bar/Components/BatteryComponent.xaml
@@ -4,9 +4,9 @@
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-  xmlns:local="clr-namespace:GlazeWM.Bar.Components"
+  xmlns:components="clr-namespace:GlazeWM.Bar.Components"
   mc:Ignorable="d">
-  <TextBlock
+  <components:Label
     VerticalAlignment="Center"
     Foreground="{Binding Foreground}"
     FontFamily="{Binding FontFamily}"

--- a/GlazeWM.Bar/Components/BatteryComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/BatteryComponentViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Reactive.Linq;
 using GlazeWM.Domain.UserConfigs;
@@ -8,48 +9,66 @@ namespace GlazeWM.Bar.Components
 {
   public class BatteryComponentViewModel : ComponentViewModel
   {
-    private readonly BatteryComponentConfig _batteryComponentConfig;
+    private readonly BatteryComponentConfig _config;
 
     /// <summary>
     /// Format the current power status with the user's formatting config.
     /// </summary>
-    public string FormattedPowerStatus => FormatLabel();
-
-    private string FormatLabel()
+    private LabelViewModel _label;
+    public LabelViewModel Label
     {
-      WindowsApiService.GetSystemPowerStatus(out var ps);
-      var batteryLevel = ps.BatteryLifePercent.ToString(CultureInfo.InvariantCulture);
-
-      // display the battery level as a 100% if no dedicated battery is available on the device
-      if (ps.BatteryFlag == 128)
-      {
-        return _batteryComponentConfig.LabelDraining.Replace("{battery_level}", "100");
-      }
-
-      if (ps.ACLineStatus == 1)
-      {
-        return _batteryComponentConfig.LabelCharging.Replace("{battery_level}", batteryLevel);
-      }
-      else if (ps.SystemStatusFlag == 1)
-      {
-        return _batteryComponentConfig.LabelPowerSaver.Replace("{battery_level}", batteryLevel);
-      }
-      else
-      {
-        return _batteryComponentConfig.LabelDraining.Replace("{battery_level}", batteryLevel);
-      }
+      get => _label;
+      protected set => SetField(ref _label, value);
     }
 
     public BatteryComponentViewModel(
       BarViewModel parentViewModel,
       BatteryComponentConfig config) : base(parentViewModel, config)
     {
-      _batteryComponentConfig = config;
+      _config = config;
 
       Observable
-        .Interval(TimeSpan.FromSeconds(3))
+        .Timer(TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(5))
         .TakeUntil(_parentViewModel.WindowClosing)
-        .Subscribe(_ => OnPropertyChanged(nameof(FormattedPowerStatus)));
+        .Subscribe(_ => Label = CreateLabel());
+    }
+
+    public LabelViewModel CreateLabel()
+    {
+      WindowsApiService.GetSystemPowerStatus(out var ps);
+      var batteryLevel = ps.BatteryLifePercent.ToString(CultureInfo.InvariantCulture);
+
+      // Display the battery level as a 100% if device has no dedicated battery.
+      if (ps.BatteryFlag == 128)
+        return XamlHelper.ParseLabel(
+          _config.LabelDraining,
+          CreateVariableDict(batteryLevel)
+        );
+
+      if (ps.ACLineStatus == 1)
+        return XamlHelper.ParseLabel(
+          _config.LabelCharging,
+          CreateVariableDict(batteryLevel)
+        );
+
+      if (ps.SystemStatusFlag == 1)
+        return XamlHelper.ParseLabel(
+          _config.LabelPowerSaver,
+          CreateVariableDict(batteryLevel)
+        );
+
+      return XamlHelper.ParseLabel(
+        _config.LabelDraining,
+        CreateVariableDict(batteryLevel)
+      );
+    }
+
+    public static Dictionary<string, string> CreateVariableDict(string batteryLevel)
+    {
+      return new()
+      {
+        { "battery_level", batteryLevel }
+      };
     }
   }
 }

--- a/GlazeWM.Bar/Components/BatteryComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/BatteryComponentViewModel.cs
@@ -42,24 +42,28 @@ namespace GlazeWM.Bar.Components
       if (ps.BatteryFlag == 128)
         return XamlHelper.ParseLabel(
           _config.LabelDraining,
-          CreateVariableDict(batteryLevel)
+          CreateVariableDict(batteryLevel),
+          this
         );
 
       if (ps.ACLineStatus == 1)
         return XamlHelper.ParseLabel(
           _config.LabelCharging,
-          CreateVariableDict(batteryLevel)
+          CreateVariableDict(batteryLevel),
+          this
         );
 
       if (ps.SystemStatusFlag == 1)
         return XamlHelper.ParseLabel(
           _config.LabelPowerSaver,
-          CreateVariableDict(batteryLevel)
+          CreateVariableDict(batteryLevel),
+          this
         );
 
       return XamlHelper.ParseLabel(
         _config.LabelDraining,
-        CreateVariableDict(batteryLevel)
+        CreateVariableDict(batteryLevel),
+        this
       );
     }
 

--- a/GlazeWM.Bar/Components/LabelComponent.xaml
+++ b/GlazeWM.Bar/Components/LabelComponent.xaml
@@ -10,6 +10,9 @@
     Foreground="{Binding Foreground}"
     FontFamily="{Binding FontFamily}"
     FontWeight="{Binding FontWeight}"
-    FontSize="{Binding FontSize}"
-    Text="fjdiosafjdiosa" />
+    FontSize="{Binding FontSize}">
+    <ItemsControl ItemsSource="{Binding Spans}">
+      <Run Text="{Binding Text}" />
+    </ItemsControl>
+  </TextBlock>
 </UserControl>

--- a/GlazeWM.Bar/Components/LabelComponent.xaml
+++ b/GlazeWM.Bar/Components/LabelComponent.xaml
@@ -5,14 +5,26 @@
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
   mc:Ignorable="d">
-  <TextBlock
+  <!-- <TextBlock
     VerticalAlignment="Center"
     Foreground="{Binding Foreground}"
     FontFamily="{Binding FontFamily}"
     FontWeight="{Binding FontWeight}"
-    FontSize="{Binding FontSize}">
-    <ItemsControl ItemsSource="{Binding Spans}">
-      <Run Text="{Binding Text}" />
-    </ItemsControl>
-  </TextBlock>
+    FontSize="{Binding FontSize}"> -->
+  <!-- <TextBlock> -->
+  <ItemsControl ItemsSource="{Binding Spans}">
+    <ItemsControl.ItemsPanel>
+      <ItemsPanelTemplate>
+        <StackPanel Orientation="Horizontal" />
+      </ItemsPanelTemplate>
+    </ItemsControl.ItemsPanel>
+    <ItemsControl.ItemTemplate>
+      <DataTemplate>
+        <TextBlock
+          Text="{Binding Text}"
+          Foreground="white" />
+      </DataTemplate>
+    </ItemsControl.ItemTemplate>
+  </ItemsControl>
+  <!-- </TextBlock> -->
 </UserControl>

--- a/GlazeWM.Bar/Components/LabelComponent.xaml
+++ b/GlazeWM.Bar/Components/LabelComponent.xaml
@@ -11,5 +11,5 @@
     FontFamily="{Binding FontFamily}"
     FontWeight="{Binding FontWeight}"
     FontSize="{Binding FontSize}"
-    Text="{Binding FormattedPowerStatus}" />
+    Text="fjdiosafjdiosa" />
 </UserControl>

--- a/GlazeWM.Bar/Components/LabelComponent.xaml
+++ b/GlazeWM.Bar/Components/LabelComponent.xaml
@@ -5,13 +5,6 @@
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
   mc:Ignorable="d">
-  <!-- <TextBlock
-    VerticalAlignment="Center"
-    Foreground="{Binding Foreground}"
-    FontFamily="{Binding FontFamily}"
-    FontWeight="{Binding FontWeight}"
-    FontSize="{Binding FontSize}"> -->
-  <!-- <TextBlock> -->
   <ItemsControl ItemsSource="{Binding Spans}">
     <ItemsControl.ItemsPanel>
       <ItemsPanelTemplate>
@@ -22,9 +15,13 @@
       <DataTemplate>
         <TextBlock
           Text="{Binding Text}"
-          Foreground="white" />
+          VerticalAlignment="Center"
+          Background="{Binding Background}"
+          Foreground="{Binding Foreground}"
+          FontFamily="{Binding FontFamily}"
+          FontWeight="{Binding FontWeight}"
+          FontSize="{Binding FontSize}" />
       </DataTemplate>
     </ItemsControl.ItemTemplate>
   </ItemsControl>
-  <!-- </TextBlock> -->
 </UserControl>

--- a/GlazeWM.Bar/Components/LabelComponent.xaml
+++ b/GlazeWM.Bar/Components/LabelComponent.xaml
@@ -1,0 +1,15 @@
+<UserControl
+  x:Class="GlazeWM.Bar.Components.LabelComponent"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  mc:Ignorable="d">
+  <TextBlock
+    VerticalAlignment="Center"
+    Foreground="{Binding Foreground}"
+    FontFamily="{Binding FontFamily}"
+    FontWeight="{Binding FontWeight}"
+    FontSize="{Binding FontSize}"
+    Text="{Binding FormattedPowerStatus}" />
+</UserControl>

--- a/GlazeWM.Bar/Components/LabelComponent.xaml.cs
+++ b/GlazeWM.Bar/Components/LabelComponent.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+
+namespace GlazeWM.Bar.Components
+{
+  /// <summary>
+  /// Interaction logic for LabelComponent.xaml
+  /// </summary>
+  public partial class LabelComponent : UserControl
+  {
+    public LabelComponent()
+    {
+      InitializeComponent();
+    }
+  }
+}

--- a/GlazeWM.Bar/Components/LabelSpan.cs
+++ b/GlazeWM.Bar/Components/LabelSpan.cs
@@ -1,0 +1,96 @@
+namespace GlazeWM.Bar.Components
+{
+  public class LabelSpan
+  {
+    public string Text { get; }
+    public string Background { get; }
+    public string Foreground { get; }
+    public string FontFamily { get; }
+    public string FontWeight { get; }
+    public string FontSize { get; }
+
+    public LabelSpan(
+      string text,
+      string background,
+      string foreground,
+      string fontFamily,
+      string fontWeight,
+      string fontSize)
+    {
+      Text = text;
+      Background = background;
+      Foreground = foreground;
+      FontFamily = fontFamily;
+      FontWeight = fontWeight;
+      FontSize = fontSize;
+    }
+  }
+}
+
+/// Usage:
+/**
+public class BatteryComponentViewModel : ComponentViewModel
+{
+  private readonly BatteryComponentConfig _config;
+
+  private LabelViewModel _label;
+  public string Label
+  {
+      get => _label;
+      protected set => SetField(ref _label, value);
+  }
+
+  public BatteryComponentViewModel(...) : base(parentViewModel, config)
+  {
+    _batteryComponentConfig = config;
+
+    Label = XamlHelper.ParseLabel(config.Label, CreateVariableDict());
+
+    Observable
+      .Interval(TimeSpan.FromSeconds(3))
+      .TakeUntil(_parentViewModel.WindowClosing)
+      .Subscribe(_ => {
+        Label.UpdateVariables(CreateVariableDict());
+        OnPropertyChanged(nameof(Label));
+      });
+  }
+}
+*/
+
+/// Alternatively:
+/**
+public class BatteryComponentViewModel : ComponentViewModel
+{
+  private readonly BatteryComponentConfig _config;
+
+  private LabelViewModel _label;
+  public string Label
+  {
+      get => _label;
+      protected set => SetField(ref _label, value);
+  }
+
+  public BatteryComponentViewModel(...) : base(parentViewModel, config)
+  {
+    _batteryComponentConfig = config;
+
+    Label = XamlHelper.ParseLabel(config.Label, GetVariableDict());
+
+    Observable
+      .Interval(TimeSpan.FromSeconds(3))
+      .TakeUntil(_parentViewModel.WindowClosing)
+      .Subscribe(_ => {
+        Label.UpdateVariables();
+        OnPropertyChanged(nameof(Label));
+      });
+  }
+
+  public Dictionary<string, Action<string>> GetVariableDict()
+  {
+    return new()
+    {
+      { "battery_level", () => GetBatteryLevel() }
+    }
+  }
+}
+*/

--- a/GlazeWM.Bar/Components/LabelViewModel.cs
+++ b/GlazeWM.Bar/Components/LabelViewModel.cs
@@ -1,35 +1,8 @@
-using System;
 using System.Collections.Generic;
 using GlazeWM.Bar.Common;
 
 namespace GlazeWM.Bar.Components
 {
-  public class LabelSpan
-  {
-    public string Text { get; }
-    public string Background { get; }
-    public string Foreground { get; }
-    public string FontFamily { get; }
-    public string FontWeight { get; }
-    public string FontSize { get; }
-
-    public LabelSpan(
-      string text,
-      string background,
-      string foreground,
-      string fontFamily,
-      string fontWeight,
-      string fontSize)
-    {
-      Text = text;
-      Background = background;
-      Foreground = foreground;
-      FontFamily = fontFamily;
-      FontWeight = fontWeight;
-      FontSize = fontSize;
-    }
-  }
-
   public class LabelViewModel : ViewModelBase
   {
     public List<LabelSpan> Spans { get; }
@@ -38,79 +11,5 @@ namespace GlazeWM.Bar.Components
     {
       Spans = spans;
     }
-
-    public void UpdateVariables(Dictionary<string, string> labelVariables)
-    {
-      // TODO
-      throw new NotImplementedException();
-    }
   }
 }
-
-/// Usage:
-/**
-public class BatteryComponentViewModel : ComponentViewModel
-{
-  private readonly BatteryComponentConfig _config;
-
-  private LabelViewModel _label;
-  public string Label
-  {
-      get => _label;
-      protected set => SetField(ref _label, value);
-  }
-
-  public BatteryComponentViewModel(...) : base(parentViewModel, config)
-  {
-    _batteryComponentConfig = config;
-
-    Label = XamlHelper.ParseLabel(config.Label, CreateVariableDict());
-
-    Observable
-      .Interval(TimeSpan.FromSeconds(3))
-      .TakeUntil(_parentViewModel.WindowClosing)
-      .Subscribe(_ => {
-        Label.UpdateVariables(CreateVariableDict());
-        OnPropertyChanged(nameof(Label));
-      });
-  }
-}
-*/
-
-/// Alternatively:
-/**
-public class BatteryComponentViewModel : ComponentViewModel
-{
-  private readonly BatteryComponentConfig _config;
-
-  private LabelViewModel _label;
-  public string Label
-  {
-      get => _label;
-      protected set => SetField(ref _label, value);
-  }
-
-  public BatteryComponentViewModel(...) : base(parentViewModel, config)
-  {
-    _batteryComponentConfig = config;
-
-    Label = XamlHelper.ParseLabel(config.Label, GetVariableDict());
-
-    Observable
-      .Interval(TimeSpan.FromSeconds(3))
-      .TakeUntil(_parentViewModel.WindowClosing)
-      .Subscribe(_ => {
-        Label.UpdateVariables();
-        OnPropertyChanged(nameof(Label));
-      });
-  }
-
-  public Dictionary<string, Action<string>> GetVariableDict()
-  {
-    return new()
-    {
-      { "battery_level", () => GetBatteryLevel() }
-    }
-  }
-}
-*/

--- a/GlazeWM.Bar/Components/LabelViewModel.cs
+++ b/GlazeWM.Bar/Components/LabelViewModel.cs
@@ -6,34 +6,37 @@ namespace GlazeWM.Bar.Components
 {
   public class LabelSpan
   {
-    public string Background { get; set; }
-    public string Foreground { get; set; }
-    public string FontFamily { get; set; }
-    public string FontWeight { get; set; }
-    public string FontSize { get; set; }
     public string Text { get; }
+    public string Background { get; }
+    public string Foreground { get; }
+    public string FontFamily { get; }
+    public string FontWeight { get; }
+    public string FontSize { get; }
 
-    public LabelSpan(string text)
+    public LabelSpan(
+      string text,
+      string background,
+      string foreground,
+      string fontFamily,
+      string fontWeight,
+      string fontSize)
     {
       Text = text;
+      Background = background;
+      Foreground = foreground;
+      FontFamily = fontFamily;
+      FontWeight = fontWeight;
+      FontSize = fontSize;
     }
   }
 
   public class LabelViewModel : ViewModelBase
   {
     public List<LabelSpan> Spans { get; }
-    private readonly ComponentViewModel ComponentViewModel;
 
-    public string Background => ComponentViewModel.Background;
-    public string Foreground => ComponentViewModel.Foreground;
-    public string FontFamily => ComponentViewModel.FontFamily;
-    public string FontWeight => ComponentViewModel.FontWeight;
-    public string FontSize => ComponentViewModel.FontSize;
-
-    public LabelViewModel(List<LabelSpan> spans, ComponentViewModel componentViewModel)
+    public LabelViewModel(List<LabelSpan> spans)
     {
       Spans = spans;
-      ComponentViewModel = componentViewModel;
     }
 
     public void UpdateVariables(Dictionary<string, string> labelVariables)

--- a/GlazeWM.Bar/Components/LabelViewModel.cs
+++ b/GlazeWM.Bar/Components/LabelViewModel.cs
@@ -4,8 +4,30 @@ using GlazeWM.Bar.Common;
 
 namespace GlazeWM.Bar.Components
 {
+  public class LabelSpan
+  {
+    public string Background { get; set; }
+    public string Foreground { get; set; }
+    public string FontFamily { get; set; }
+    public string FontWeight { get; set; }
+    public string FontSize { get; set; }
+    public string Text { get; }
+
+    public LabelSpan(string text)
+    {
+      Text = text;
+    }
+  }
+
   public class LabelViewModel : ViewModelBase
   {
+    public List<LabelSpan> Spans { get; set; }
+
+    public LabelViewModel(List<LabelSpan> spans)
+    {
+      Spans = spans;
+    }
+
     public void UpdateVariables(Dictionary<string, string> labelVariables)
     {
       // TODO

--- a/GlazeWM.Bar/Components/LabelViewModel.cs
+++ b/GlazeWM.Bar/Components/LabelViewModel.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using GlazeWM.Bar.Common;
+
+namespace GlazeWM.Bar.Components
+{
+  public class LabelViewModel : ViewModelBase
+  {
+    public void UpdateVariables(Dictionary<string, string> labelVariables)
+    {
+      // TODO
+      throw new NotImplementedException();
+    }
+  }
+}
+
+/// Usage:
+/**
+public class BatteryComponentViewModel : ComponentViewModel
+{
+  private readonly BatteryComponentConfig _config;
+
+  private LabelViewModel _label;
+  public string Label
+  {
+      get => _label;
+      protected set => SetField(ref _label, value);
+  }
+
+  public BatteryComponentViewModel(...) : base(parentViewModel, config)
+  {
+    _batteryComponentConfig = config;
+
+    Label = XamlHelper.ParseLabel(config.Label, CreateVariableDict());
+
+    Observable
+      .Interval(TimeSpan.FromSeconds(3))
+      .TakeUntil(_parentViewModel.WindowClosing)
+      .Subscribe(_ => {
+        Label.UpdateVariables(CreateVariableDict());
+        OnPropertyChanged(nameof(Label));
+      });
+  }
+}
+*/
+
+/// Alternatively:
+/**
+public class BatteryComponentViewModel : ComponentViewModel
+{
+  private readonly BatteryComponentConfig _config;
+
+  private LabelViewModel _label;
+  public string Label
+  {
+      get => _label;
+      protected set => SetField(ref _label, value);
+  }
+
+  public BatteryComponentViewModel(...) : base(parentViewModel, config)
+  {
+    _batteryComponentConfig = config;
+
+    Label = XamlHelper.ParseLabel(config.Label, GetVariableDict());
+
+    Observable
+      .Interval(TimeSpan.FromSeconds(3))
+      .TakeUntil(_parentViewModel.WindowClosing)
+      .Subscribe(_ => {
+        Label.UpdateVariables();
+        OnPropertyChanged(nameof(Label));
+      });
+  }
+
+  public Dictionary<string, Action<string>> GetVariableDict()
+  {
+    return new()
+    {
+      { "battery_level", () => GetBatteryLevel() }
+    }
+  }
+}
+*/

--- a/GlazeWM.Bar/Components/LabelViewModel.cs
+++ b/GlazeWM.Bar/Components/LabelViewModel.cs
@@ -21,11 +21,19 @@ namespace GlazeWM.Bar.Components
 
   public class LabelViewModel : ViewModelBase
   {
-    public List<LabelSpan> Spans { get; set; }
+    public List<LabelSpan> Spans { get; }
+    private readonly ComponentViewModel ComponentViewModel;
 
-    public LabelViewModel(List<LabelSpan> spans)
+    public string Background => ComponentViewModel.Background;
+    public string Foreground => ComponentViewModel.Foreground;
+    public string FontFamily => ComponentViewModel.FontFamily;
+    public string FontWeight => ComponentViewModel.FontWeight;
+    public string FontSize => ComponentViewModel.FontSize;
+
+    public LabelViewModel(List<LabelSpan> spans, ComponentViewModel componentViewModel)
     {
       Spans = spans;
+      ComponentViewModel = componentViewModel;
     }
 
     public void UpdateVariables(Dictionary<string, string> labelVariables)

--- a/GlazeWM.Bar/XamlHelper.cs
+++ b/GlazeWM.Bar/XamlHelper.cs
@@ -61,7 +61,8 @@ namespace GlazeWM.Bar
 
     public static LabelViewModel ParseLabel(
       string labelString,
-      Dictionary<string, string> labelVariables)
+      Dictionary<string, string> labelVariables,
+      ComponentViewModel viewModel)
     {
       var labelWithVariables = labelString;
 
@@ -70,20 +71,25 @@ namespace GlazeWM.Bar
         labelWithVariables = labelWithVariables.Replace($"{{{key}}}", value);
 
       // Wrap `labelString` in arbitrary tag to make it valid XML.
-      var wrappedLabel = $"<Label>{labelString}</Label>";
+      var wrappedLabel = $"<Label>{labelWithVariables}</Label>";
       var labelXml = XElement.Parse(wrappedLabel);
+
+      var x = labelXml.Descendants();
 
       var labelNode = labelXml.FirstNode;
       var labelSpans = new List<LabelSpan>();
 
       while (labelNode is not null)
       {
-        var labelSpan = new LabelSpan(labelNode.ToString());
+        var nodeValue = labelNode.ToString();
+        var labelSpan = new LabelSpan(nodeValue);
         labelSpans.Add(labelSpan);
+
+        // Traverse to next node.
         labelNode = labelNode.NextNode;
       }
 
-      return new LabelViewModel(labelSpans);
+      return new LabelViewModel(labelSpans, viewModel);
     }
   }
 }

--- a/GlazeWM.Bar/XamlHelper.cs
+++ b/GlazeWM.Bar/XamlHelper.cs
@@ -73,7 +73,17 @@ namespace GlazeWM.Bar
       var wrappedLabel = $"<Label>{labelString}</Label>";
       var labelXml = XElement.Parse(wrappedLabel);
 
-      return new LabelViewModel();
+      var labelNode = labelXml.FirstNode;
+      var labelSpans = new List<LabelSpan>();
+
+      while (labelNode is not null)
+      {
+        var labelSpan = new LabelSpan(labelNode.ToString());
+        labelSpans.Add(labelSpan);
+        labelNode = labelNode.NextNode;
+      }
+
+      return new LabelViewModel(labelSpans);
     }
   }
 }

--- a/GlazeWM.Bar/XamlHelper.cs
+++ b/GlazeWM.Bar/XamlHelper.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
-using System.Xml.XPath;
 using GlazeWM.Bar.Components;
 using GlazeWM.Infrastructure.Utils;
 
@@ -75,37 +74,17 @@ namespace GlazeWM.Bar
       var wrappedLabel = $"<Label>{labelWithVariables}</Label>";
       var labelXml = XElement.Parse(wrappedLabel);
 
-      // var x = labelXml.DescendantNodesAndSelf();
-      var x = labelXml.DescendantsAndSelf();
-
-      var yyy = labelXml.Nodes().Aggregate("", (b, node) =>
+      var labelSpans = labelXml.Nodes().Select(node =>
       {
-        var yy = node;
-        var text = node as XText;
-        var element = node as XElement;
-        return b += node.ToString();
-      });
+        var value = node switch
+        {
+          XText text => text.Value,
+          XElement element => element.Value,
+          _ => throw new ArgumentException("Invalid XML.", nameof(labelString))
+        };
 
-      var yyyy = labelXml.CreateNavigator().InnerXml;
-
-      foreach (var y in x)
-      {
-        var value = y.Value;
-        var value2 = y.ToString();
-        // var value3 = y.
-      }
-      var labelNode = labelXml.FirstNode;
-      var labelSpans = new List<LabelSpan>();
-
-      while (labelNode is not null)
-      {
-        var nodeValue = labelNode.ToString();
-        var labelSpan = new LabelSpan(nodeValue);
-        labelSpans.Add(labelSpan);
-
-        // Traverse to next node.
-        labelNode = labelNode.NextNode;
-      }
+        return new LabelSpan(value);
+      }).ToList();
 
       return new LabelViewModel(labelSpans, viewModel);
     }

--- a/GlazeWM.Bar/XamlHelper.cs
+++ b/GlazeWM.Bar/XamlHelper.cs
@@ -59,9 +59,9 @@ namespace GlazeWM.Bar
       };
     }
 
-    public static XElement ParseLabel(
-      Dictionary<string, string> labelVariables,
-      string labelString)
+    public static LabelViewModel ParseLabel(
+      string labelString,
+      Dictionary<string, string> labelVariables)
     {
       var labelWithVariables = labelString;
 
@@ -69,10 +69,11 @@ namespace GlazeWM.Bar
       foreach (var (key, value) in labelVariables)
         labelWithVariables = labelWithVariables.Replace($"{{{key}}}", value);
 
+      // Wrap `labelString` in arbitrary tag to make it valid XML.
       var wrappedLabel = $"<Label>{labelString}</Label>";
       var labelXml = XElement.Parse(wrappedLabel);
 
-      return labelXml;
+      return new LabelViewModel();
     }
   }
 }

--- a/GlazeWM.Bar/XamlHelper.cs
+++ b/GlazeWM.Bar/XamlHelper.cs
@@ -83,10 +83,23 @@ namespace GlazeWM.Bar
           _ => throw new ArgumentException("Invalid XML.", nameof(labelString))
         };
 
-        return new LabelSpan(value);
+        string foreground = null;
+        string background = null;
+        string fontFamily = null;
+        string fontWeight = null;
+        string fontSize = null;
+
+        return new LabelSpan(
+          value,
+          foreground ?? viewModel.Foreground,
+          background ?? viewModel.Background,
+          fontFamily ?? viewModel.FontFamily,
+          fontWeight ?? viewModel.FontWeight,
+          fontSize ?? viewModel.FontSize
+        );
       }).ToList();
 
-      return new LabelViewModel(labelSpans, viewModel);
+      return new LabelViewModel(labelSpans);
     }
   }
 }

--- a/GlazeWM.Bar/XamlHelper.cs
+++ b/GlazeWM.Bar/XamlHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
+using System.Xml.XPath;
 using GlazeWM.Bar.Components;
 using GlazeWM.Infrastructure.Utils;
 
@@ -74,8 +75,25 @@ namespace GlazeWM.Bar
       var wrappedLabel = $"<Label>{labelWithVariables}</Label>";
       var labelXml = XElement.Parse(wrappedLabel);
 
-      var x = labelXml.Descendants();
+      // var x = labelXml.DescendantNodesAndSelf();
+      var x = labelXml.DescendantsAndSelf();
 
+      var yyy = labelXml.Nodes().Aggregate("", (b, node) =>
+      {
+        var yy = node;
+        var text = node as XText;
+        var element = node as XElement;
+        return b += node.ToString();
+      });
+
+      var yyyy = labelXml.CreateNavigator().InnerXml;
+
+      foreach (var y in x)
+      {
+        var value = y.Value;
+        var value2 = y.ToString();
+        // var value3 = y.
+      }
       var labelNode = labelXml.FirstNode;
       var labelSpans = new List<LabelSpan>();
 

--- a/GlazeWM.Bar/XamlHelper.cs
+++ b/GlazeWM.Bar/XamlHelper.cs
@@ -83,16 +83,30 @@ namespace GlazeWM.Bar
           _ => throw new ArgumentException("Invalid XML.", nameof(labelString))
         };
 
-        string foreground = null;
         string background = null;
+        string foreground = null;
         string fontFamily = null;
         string fontWeight = null;
         string fontSize = null;
 
+        var ancestor = node;
+
+        while (ancestor is not null)
+        {
+          background ??= (ancestor as XElement)?.Attribute("bg")?.Value;
+          foreground ??= (ancestor as XElement)?.Attribute("fg")?.Value;
+          fontFamily ??= (ancestor as XElement)?.Attribute("ff")?.Value;
+          fontWeight ??= (ancestor as XElement)?.Attribute("fw")?.Value;
+          fontSize ??= (ancestor as XElement)?.Attribute("fs")?.Value;
+
+          // Traverse upwards to get attributes to apply.
+          ancestor = ancestor.Parent;
+        }
+
         return new LabelSpan(
           value,
-          foreground ?? viewModel.Foreground,
           background ?? viewModel.Background,
+          foreground ?? viewModel.Foreground,
           fontFamily ?? viewModel.FontFamily,
           fontWeight ?? viewModel.FontWeight,
           fontSize ?? viewModel.FontSize

--- a/GlazeWM.Bar/XamlHelper.cs
+++ b/GlazeWM.Bar/XamlHelper.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Xml.Linq;
+using GlazeWM.Bar.Components;
 using GlazeWM.Infrastructure.Utils;
 
 namespace GlazeWM.Bar
@@ -54,6 +57,22 @@ namespace GlazeWM.Bar
         4 => $"{shorthandParts[3]},{shorthandParts[0]},{shorthandParts[1]},{shorthandParts[2]}",
         _ => throw new ArgumentException(null, nameof(shorthand)),
       };
+    }
+
+    public static XElement ParseLabel(
+      Dictionary<string, string> labelVariables,
+      string labelString)
+    {
+      var labelWithVariables = labelString;
+
+      // Replace variables in label with their corresponding variable.
+      foreach (var (key, value) in labelVariables)
+        labelWithVariables = labelWithVariables.Replace($"{{{key}}}", value);
+
+      var wrappedLabel = $"<Label>{labelString}</Label>";
+      var labelXml = XElement.Parse(wrappedLabel);
+
+      return labelXml;
     }
   }
 }


### PR DESCRIPTION
* Allows mixing of foreground, background, font family, font weight, and font size, within a label.
* Supported attributes:
  * Foreground: `ff`
  * Background: `bg`
  * Font family: `ff`
  * Font weight: `fw`
  * Font size: `fs`


Example:
```yaml
components_right:
  - type: "battery"
    label_draining: <attr ff="Arial">{battery_level}</attr>%
    label_charging: {battery_level}<attr fg="blue">%</attr>
    label_power_saver: <attr ff="Arial" fg="blue">{battery_level}%</attr>
```