### PR TITLE
feat: alias Ctrl to Control

### DIFF
--- a/GlazeWM.Infrastructure/Utils/KeybindingHelper.cs
+++ b/GlazeWM.Infrastructure/Utils/KeybindingHelper.cs
@@ -25,13 +25,19 @@ namespace GlazeWM.Infrastructure.Utils
 
     private static Keys ParseKeyString(string keyString)
     {
-      try
+      switch (keyString)
       {
-        return Enum.Parse<Keys>(keyString);
-      }
-      catch (ArgumentException)
-      {
-        throw new ArgumentException($"Unknown key '{keyString}'");
+        case "Ctrl":
+          return Keys.Control;
+        default:
+          try
+          {
+            return Enum.Parse<Keys>(keyString);
+          }
+          catch (ArgumentException)
+          {
+            throw new ArgumentException($"Unknown key '{keyString}'");
+          }
       }
     }
   }

--- a/GlazeWM.Infrastructure/Utils/KeybindingHelper.cs
+++ b/GlazeWM.Infrastructure/Utils/KeybindingHelper.cs
@@ -25,19 +25,17 @@ namespace GlazeWM.Infrastructure.Utils
 
     private static Keys ParseKeyString(string keyString)
     {
-      switch (keyString)
+      try
       {
-        case "Ctrl":
-          return Keys.Control;
-        default:
-          try
-          {
-            return Enum.Parse<Keys>(keyString);
-          }
-          catch (ArgumentException)
-          {
-            throw new ArgumentException($"Unknown key '{keyString}'");
-          }
+        return Enum.Parse<Keys>(keyString);
+      }
+      catch (ArgumentException)
+      {
+        return keyString switch
+        {
+          "Ctrl" => Keys.Control,
+          _ => throw new ArgumentException($"Unknown key '{keyString}'"),
+        };
       }
     }
   }


### PR DESCRIPTION
Tiny PR here. 

I grabbed some low-hanging fruit from the "Free to take" list. https://github.com/users/lars-berger/projects/2/views/1?pane=issue&itemId=28116872

I chose to implement this with a switch so that more keybinding aliasing could be done quickly in future (e.g. Meta -> Alt)

Ignore the completely overwritten first commit, I decided as I was drafting this PR that it'd be better to check against the Enum first before moving on to the switch so there's not a whole bunch of unnecessary comparisons. 