### PR TITLE
feat: Allow setting bar as overlay

### DIFF
--- a/GlazeWM.Bar/BarViewModel.cs
+++ b/GlazeWM.Bar/BarViewModel.cs
@@ -19,7 +19,7 @@ namespace GlazeWM.Bar
     public BarConfig BarConfig { get; }
 
     public BarPosition Position => BarConfig.Position;
-    public bool show_bar_as_overlay => BarConfig.show_bar_as_overlay;
+    public bool AlwaysOnTop => BarConfig.AlwaysOnTop;
     public string Background => XamlHelper.FormatColor(BarConfig.Background);
     public string Foreground => XamlHelper.FormatColor(BarConfig.Foreground);
     public string FontFamily => BarConfig.FontFamily;

--- a/GlazeWM.Bar/BarViewModel.cs
+++ b/GlazeWM.Bar/BarViewModel.cs
@@ -19,6 +19,7 @@ namespace GlazeWM.Bar
     public BarConfig BarConfig { get; }
 
     public BarPosition Position => BarConfig.Position;
+    public bool show_bar_as_overlay => BarConfig.show_bar_as_overlay;
     public string Background => XamlHelper.FormatColor(BarConfig.Background);
     public string Foreground => XamlHelper.FormatColor(BarConfig.Foreground);
     public string FontFamily => BarConfig.FontFamily;

--- a/GlazeWM.Bar/MainWindow.xaml
+++ b/GlazeWM.Bar/MainWindow.xaml
@@ -19,7 +19,7 @@
   FontSize="{Binding FontSize}"
   Opacity="{Binding Opacity}"
   AllowsTransparency="True"
-  Topmost="False">
+  Topmost="{Binding show_bar_as_overlay}">
   <Border
     CornerRadius="{Binding BorderRadius}"
     BorderThickness="{Binding BorderWidth}"

--- a/GlazeWM.Bar/MainWindow.xaml
+++ b/GlazeWM.Bar/MainWindow.xaml
@@ -19,7 +19,7 @@
   FontSize="{Binding FontSize}"
   Opacity="{Binding Opacity}"
   AllowsTransparency="True"
-  Topmost="{Binding show_bar_as_overlay}">
+  Topmost="{Binding AlwaysOnTop}">
   <Border
     CornerRadius="{Binding BorderRadius}"
     BorderThickness="{Binding BorderWidth}"

--- a/GlazeWM.Domain/UserConfigs/BarConfig.cs
+++ b/GlazeWM.Domain/UserConfigs/BarConfig.cs
@@ -6,6 +6,8 @@ namespace GlazeWM.Domain.UserConfigs
   {
     public bool Enabled { get; set; } = true;
 
+    public bool show_bar_as_overlay { get; set; } = false;
+
     public string OffsetX { get; set; } = "0px";
 
     public string OffsetY { get; set; } = "0px";

--- a/GlazeWM.Domain/UserConfigs/BarConfig.cs
+++ b/GlazeWM.Domain/UserConfigs/BarConfig.cs
@@ -6,7 +6,7 @@ namespace GlazeWM.Domain.UserConfigs
   {
     public bool Enabled { get; set; } = true;
 
-    public bool show_bar_as_overlay { get; set; } = false;
+    public bool AlwaysOnTop { get; set; } = false;
 
     public string OffsetX { get; set; } = "0px";
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ bar:
   # The position of the bar on the screen. Can be either "top" or "bottom".
   position: "top"
 
+  # Whether to show the bar above other windows
+  always_on_top: false
+
   # Opacity value between 0.0 and 1.0.
   opacity: 1.0
 


### PR DESCRIPTION
Allows setting `show_bar_as_overlay: true` which makes the bar appear on top

This, coupled with #282 should address #340 

preview:

![image](https://github.com/lars-berger/GlazeWM/assets/74417622/e603f6a8-bd30-42af-9bfd-3afd00c056b0)

![image](https://github.com/lars-berger/GlazeWM/assets/74417622/c36626ca-b9d2-42a7-bcbf-079aa175c530)


