### PR TITLE
fix: compilation error in `VolumeComponentViewModel`

### DIFF
--- a/GlazeWM.Bar/Components/VolumeComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/VolumeComponentViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using GlazeWM.Domain.UserConfigs;
@@ -57,12 +58,12 @@ namespace GlazeWM.Bar.Components
       );
     }
 
-    public static Dictionary<string, string> CreateVariableDict(
+    public static Dictionary<string, Func<string>> CreateVariableDict(
       VolumeInformation volumeInfo)
     {
       return new()
       {
-        { "volume_level", volumeInfo.Volume.ToString("0", CultureInfo.InvariantCulture) },
+        { "volume_level", () => volumeInfo.Volume.ToString("0", CultureInfo.InvariantCulture) },
       };
     }
   }


### PR DESCRIPTION
I was unable to compile the solution after some PRs were merged over the last few days. Looks like one of the methods is now expecting a `Dictionary<string, Func<string>>` instead of `Dictionary<string, string>`