### PR TITLE
fix: update id when the `Container` type changes

### DIFF
--- a/GlazeWM.Domain/Containers/CommandHandlers/RedrawContainersHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/RedrawContainersHandler.cs
@@ -68,8 +68,7 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
         SetWindowPosFlags.FrameChanged |
         SetWindowPosFlags.NoActivate |
         SetWindowPosFlags.NoCopyBits |
-        SetWindowPosFlags.NoSendChanging |
-        SetWindowPosFlags.AsyncWindowPos;
+        SetWindowPosFlags.NoSendChanging;
 
       // Show or hide the window depending on whether the workspace is displayed.
       if (window.IsDisplayed)

--- a/GlazeWM.Domain/Containers/Container.cs
+++ b/GlazeWM.Domain/Containers/Container.cs
@@ -11,7 +11,7 @@ namespace GlazeWM.Domain.Containers
     /// <summary>
     /// A unique identifier for the container.
     /// </summary>
-    public Guid Id { get; } = Guid.NewGuid();
+    public Guid Id { get; set; } = Guid.NewGuid();
 
     /// <summary>
     /// Derived container type (eg. `ContainerType.Monitor`).

--- a/GlazeWM.Domain/UserConfigs/CommandHandlers/RegisterKeybindingsHandler.cs
+++ b/GlazeWM.Domain/UserConfigs/CommandHandlers/RegisterKeybindingsHandler.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using GlazeWM.Domain.UserConfigs.Commands;
 using GlazeWM.Domain.Windows;
 using GlazeWM.Infrastructure.Bussing;
+using GlazeWM.Infrastructure.Common.Commands;
 using GlazeWM.Infrastructure.WindowsApi;
 using static GlazeWM.Infrastructure.WindowsApi.WindowsApiService;
 
@@ -41,11 +43,19 @@ namespace GlazeWM.Domain.UserConfigs.CommandHandlers
           {
             Task.Run(() =>
             {
-              // Avoid invoking keybinding if an ignored window currently has focus.
-              if (_windowService.IgnoredHandles.Contains(GetForegroundWindow()))
-                return;
+              try
+              {
+                // Avoid invoking keybinding if an ignored window currently has focus.
+                if (_windowService.IgnoredHandles.Contains(GetForegroundWindow()))
+                  return;
 
-              _bus.Invoke(new RunWithSubjectContainerCommand(commandStrings));
+                _bus.Invoke(new RunWithSubjectContainerCommand(commandStrings));
+              }
+              catch (Exception e)
+              {
+                _bus.Invoke(new HandleFatalExceptionCommand(e));
+                throw;
+              }
             });
           });
       }

--- a/GlazeWM.Domain/UserConfigs/CommandHandlers/RegisterKeybindingsHandler.cs
+++ b/GlazeWM.Domain/UserConfigs/CommandHandlers/RegisterKeybindingsHandler.cs
@@ -1,11 +1,7 @@
-using System;
 using System.Linq;
-using System.Threading.Tasks;
-using GlazeWM.Domain.Containers;
 using GlazeWM.Domain.UserConfigs.Commands;
 using GlazeWM.Domain.Windows;
 using GlazeWM.Infrastructure.Bussing;
-using GlazeWM.Infrastructure.Common.Commands;
 using GlazeWM.Infrastructure.WindowsApi;
 using static GlazeWM.Infrastructure.WindowsApi.WindowsApiService;
 
@@ -42,22 +38,11 @@ namespace GlazeWM.Domain.UserConfigs.CommandHandlers
         foreach (var binding in keybindingConfig.BindingList)
           _keybindingService.AddGlobalKeybinding(binding, () =>
           {
-            Task.Run(() =>
-            {
-              try
-              {
-                // Avoid invoking keybinding if an ignored window currently has focus.
-                if (_windowService.IgnoredHandles.Contains(GetForegroundWindow()))
-                  return;
+            // Avoid invoking keybinding if an ignored window currently has focus.
+            if (_windowService.IgnoredHandles.Contains(GetForegroundWindow()))
+              return;
 
-                _bus.Invoke(new RunWithSubjectContainerCommand(commandStrings));
-              }
-              catch (Exception e)
-              {
-                _bus.Invoke(new HandleFatalExceptionCommand(e));
-                throw;
-              }
-            });
+            _bus.InvokeAsync(new RunWithSubjectContainerCommand(commandStrings));
           });
       }
 

--- a/GlazeWM.Domain/UserConfigs/CommandHandlers/RegisterKeybindingsHandler.cs
+++ b/GlazeWM.Domain/UserConfigs/CommandHandlers/RegisterKeybindingsHandler.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading.Tasks;
 using GlazeWM.Domain.UserConfigs.Commands;
 using GlazeWM.Domain.Windows;
 using GlazeWM.Infrastructure.Bussing;
@@ -38,11 +39,14 @@ namespace GlazeWM.Domain.UserConfigs.CommandHandlers
         foreach (var binding in keybindingConfig.BindingList)
           _keybindingService.AddGlobalKeybinding(binding, () =>
           {
-            // Avoid invoking keybinding if an ignored window currently has focus.
-            if (_windowService.IgnoredHandles.Contains(GetForegroundWindow()))
-              return;
+            Task.Run(() =>
+            {
+              // Avoid invoking keybinding if an ignored window currently has focus.
+              if (_windowService.IgnoredHandles.Contains(GetForegroundWindow()))
+                return;
 
-            _bus.InvokeAsync(new RunWithSubjectContainerCommand(commandStrings));
+              _bus.Invoke(new RunWithSubjectContainerCommand(commandStrings));
+            });
           });
       }
 

--- a/GlazeWM.Domain/UserConfigs/CommandHandlers/RunWithSubjectContainerHandler.cs
+++ b/GlazeWM.Domain/UserConfigs/CommandHandlers/RunWithSubjectContainerHandler.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using GlazeWM.Domain.Containers;
 using GlazeWM.Domain.UserConfigs.Commands;
 using GlazeWM.Infrastructure.Bussing;
+using GlazeWM.Infrastructure.Utils;
 
 namespace GlazeWM.Domain.UserConfigs.CommandHandlers
 {
@@ -24,15 +25,15 @@ namespace GlazeWM.Domain.UserConfigs.CommandHandlers
 
     public CommandResponse Handle(RunWithSubjectContainerCommand command)
     {
-      var commandStrings = command.CommandStrings;
+      var commandStrings = command.CommandStrings.ToList();
       var subjectContainer =
         command.SubjectContainer ?? _containerService.FocusedContainer;
 
       var subjectContainerId = subjectContainer.Id;
 
-      // Return early if any of the commands is an ignore command.
+      // Evaluate ignore rules first (avoids jitters if another rule triggers a redraw).
       if (commandStrings.Any(command => command == "ignore"))
-        return CommandResponse.Ok;
+        commandStrings.MoveToFront("ignore");
 
       // Invoke commands in sequence.
       foreach (var commandString in commandStrings)

--- a/GlazeWM.Domain/Windows/CommandHandlers/SetFloatingHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/SetFloatingHandler.cs
@@ -35,7 +35,10 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
         window.Handle,
         window.FloatingPlacement,
         window.BorderDelta
-      );
+      )
+      {
+        Id = window.Id
+      };
 
       _bus.Invoke(new ReplaceContainerCommand(floatingWindow, window.Parent, window.Index));
       _bus.Invoke(new RedrawContainersCommand());

--- a/GlazeWM.Domain/Windows/CommandHandlers/SetTilingHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/SetTilingHandler.cs
@@ -32,7 +32,10 @@ namespace GlazeWM.Domain.Windows.CommandHandlers
         window.FloatingPlacement,
         window.BorderDelta,
         0
-      );
+      )
+      {
+        Id = window.Id
+      };
 
       // Replace the original window with the created tiling window.
       _bus.Invoke(new ReplaceContainerCommand(tilingWindow, window.Parent, window.Index));

--- a/GlazeWM.Domain/Windows/EventHandlers/WindowFocusedHandler.cs
+++ b/GlazeWM.Domain/Windows/EventHandlers/WindowFocusedHandler.cs
@@ -68,13 +68,8 @@ namespace GlazeWM.Domain.Windows.EventHandlers
       var window = _windowService.GetWindows()
         .FirstOrDefault(window => window.Handle == @event.WindowHandle);
 
-      if (window is null)
+      if (window is null || window?.IsDisplayed == false)
         return;
-      if (!window.IsDisplayed)
-      {
-        var offScreenWorkspace = WorkspaceService.GetWorkspaceFromChildContainer(window);
-        _bus.Invoke(new FocusWorkspaceCommand(offScreenWorkspace.Name));
-      }
 
       _logger.LogWindowEvent("Window focused", window);
 

--- a/GlazeWM.Domain/Windows/EventHandlers/WindowMinimizeEndedHandler.cs
+++ b/GlazeWM.Domain/Windows/EventHandlers/WindowMinimizeEndedHandler.cs
@@ -68,7 +68,7 @@ namespace GlazeWM.Domain.Windows.EventHandlers
 
     private static Window CreateWindowFromPreviousState(MinimizedWindow window)
     {
-      return window.PreviousState switch
+      Window restoredWindow = window.PreviousState switch
       {
         WindowType.Floating => new FloatingWindow(
           window.Handle,
@@ -95,6 +95,9 @@ namespace GlazeWM.Domain.Windows.EventHandlers
         WindowType.Minimized => throw new ArgumentException(null, nameof(window)),
         _ => throw new ArgumentException(null, nameof(window)),
       };
+
+      restoredWindow.Id = window.Id;
+      return restoredWindow;
     }
   }
 }

--- a/GlazeWM.Domain/Windows/EventHandlers/WindowMinimizedHandler.cs
+++ b/GlazeWM.Domain/Windows/EventHandlers/WindowMinimizedHandler.cs
@@ -50,7 +50,10 @@ namespace GlazeWM.Domain.Windows.EventHandlers
         window.FloatingPlacement,
         window.BorderDelta,
         previousState
-      );
+      )
+      {
+        Id = window.Id
+      };
 
       // Get container to switch focus to after the window has been minimized.
       var focusTarget = WindowService.GetFocusTargetAfterRemoval(window);

--- a/GlazeWM.Domain/Workspaces/CommandHandlers/MoveWindowToWorkspaceHandler.cs
+++ b/GlazeWM.Domain/Workspaces/CommandHandlers/MoveWindowToWorkspaceHandler.cs
@@ -54,18 +54,10 @@ namespace GlazeWM.Domain.Workspaces.CommandHandlers
 
       var focusTarget = WindowService.GetFocusTargetAfterRemoval(windowToMove);
 
-      // Since the workspace that gets displayed is the last focused child, focus needs to be
-      // reassigned to the displayed workspace.
-      var targetMonitor = targetWorkspace.Parent as Monitor;
-      var focusResetTarget = targetWorkspace.IsDisplayed ? null : targetMonitor.LastFocusedDescendant;
-
       if (windowToMove is TilingWindow)
         MoveTilingWindowToWorkspace(windowToMove as TilingWindow, targetWorkspace);
       else
         _bus.Invoke(new MoveContainerWithinTreeCommand(windowToMove, targetWorkspace, false));
-
-      if (focusResetTarget is not null)
-        _bus.Invoke(new SetFocusedDescendantCommand(focusResetTarget));
 
       // Reassign focus to descendant within the current workspace. Need to call
       // `SetFocusedDescendantCommand` for when commands like `FocusWorkspaceCommand` are called


### PR DESCRIPTION
* Update container ID when the `Container` type changes (eg. `TilingWindow` -> `FloatingWindow`). This fixes the issue with window rules not being ran.
* Revert the changes from #366 (caused issues when moving windows between workspaces).